### PR TITLE
moved TriggerableStage interface into its own file

### DIFF
--- a/orc/core/include/project.h
+++ b/orc/core/include/project.h
@@ -74,7 +74,7 @@ struct NodeCapabilities {
  */
 using TriggerProgressCallback = std::function<void(size_t current, size_t total, const std::string& message)>;
 
-// Forward declaration from ld_sink_stage.h
+// Forward declaration from triggerable_stage.h
 class TriggerableStage;
 
 namespace project_io {

--- a/orc/core/project.cpp
+++ b/orc/core/project.cpp
@@ -34,7 +34,7 @@
 #include "stage_registry.h"
 #include "project_to_dag.h"
 #include "dag_executor.h"
-#include "stages/ld_sink/ld_sink_stage.h"
+#include "stages/triggerable_stage.h"
 #include "observation_context.h"
 #include <fstream>
 #include <filesystem>

--- a/orc/core/stages/audio_sink/audio_sink_stage.h
+++ b/orc/core/stages/audio_sink/audio_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include <string>
 #include <memory>
 #include <functional>

--- a/orc/core/stages/burst_level_analysis_sink/burst_level_analysis_sink_stage.h
+++ b/orc/core/stages/burst_level_analysis_sink/burst_level_analysis_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include "burst_level_analysis_types.h"
 #include <atomic>
 #include <map>

--- a/orc/core/stages/cc_sink/cc_sink_stage.h
+++ b/orc/core/stages/cc_sink/cc_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include <string>
 #include <memory>
 #include <functional>

--- a/orc/core/stages/chroma_sink/chroma_sink_stage.h
+++ b/orc/core/stages/chroma_sink/chroma_sink_stage.h
@@ -22,7 +22,7 @@
 #include <orc_source_parameters.h>
 #include "previewable_stage.h"
 #include "preview_renderer.h"  // For PreviewImage definition
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 
 #include <atomic>
 #include <thread>

--- a/orc/core/stages/dropout_analysis_sink/dropout_analysis_sink_stage.h
+++ b/orc/core/stages/dropout_analysis_sink/dropout_analysis_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include "dropout_analysis_types.h"
 #include <atomic>
 #include <map>

--- a/orc/core/stages/efm_sink/efm_sink_stage.h
+++ b/orc/core/stages/efm_sink/efm_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include <string>
 #include <memory>
 #include <functional>

--- a/orc/core/stages/hackdac_sink/hackdac_sink_stage.h
+++ b/orc/core/stages/hackdac_sink/hackdac_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include <atomic>
 #include <map>
 #include <optional>

--- a/orc/core/stages/ld_sink/ld_sink_stage.h
+++ b/orc/core/stages/ld_sink/ld_sink_stage.h
@@ -15,6 +15,7 @@
 #include <node_type.h>
 #include "video_field_representation.h"
 #include "../../tbc_source_internal/tbc_metadata.h"
+#include "../triggerable_stage.h"
 #include "previewable_stage.h"
 #include "observation_context.h"
 #include "observation_schema.h"
@@ -24,74 +25,6 @@
 #include <atomic>
 
 namespace orc {
-
-/**
- * @brief Progress callback for triggerable stages
- * 
- * @param current Current progress value (e.g., frames processed)
- * @param total Total work to be done (e.g., total frames)
- * @param message Status message describing current operation
- */
-using TriggerProgressCallback = std::function<void(size_t current, size_t total, const std::string& message)>;
-
-/**
- * @brief Triggerable interface for stages that can be manually executed
- * 
- * Stages that implement this interface can be triggered from the GUI,
- * causing them to process their entire input range and perform their action.
- */
-class TriggerableStage {
-public:
-    virtual ~TriggerableStage() = default;
-    
-    /**
-     * @brief Trigger the stage to process its input
-     * 
-     * For sinks, this means reading all fields from input and writing to output file.
-     * 
-     * @param inputs Input artifacts (typically one VideoFieldRepresentation)
-     * @param parameters Stage parameters
-     * @return True if trigger succeeded, false otherwise
-     */
-    virtual bool trigger(
-        const std::vector<ArtifactPtr>& inputs,
-        const std::map<std::string, ParameterValue>& parameters,
-        ObservationContext& observation_context
-    ) = 0;
-    
-    /**
-     * @brief Get status message after trigger
-     * @return Status message describing what was done
-     */
-    virtual std::string get_trigger_status() const = 0;
-    
-    /**
-     * @brief Set progress callback for long-running trigger operations
-     * 
-     * @param callback Function to call with progress updates (current, total, message)
-     */
-    virtual void set_progress_callback(TriggerProgressCallback callback) {
-        (void)callback; // Default implementation does nothing
-    }
-    
-    /**
-     * @brief Check if trigger is currently in progress
-     * @return True if trigger is running, false otherwise
-     */
-    virtual bool is_trigger_in_progress() const {
-        return false; // Default implementation assumes no async operation
-    }
-    
-    /**
-     * @brief Cancel an in-progress trigger operation
-     * 
-     * Only relevant for stages that support async trigger operations.
-     * Default implementation does nothing.
-     */
-    virtual void cancel_trigger() {
-        // Default implementation does nothing
-    }
-};
 
 /**
  * @brief ld-decode Sink Stage

--- a/orc/core/stages/snr_analysis_sink/snr_analysis_sink_stage.h
+++ b/orc/core/stages/snr_analysis_sink/snr_analysis_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../ld_sink/ld_sink_stage.h"  // For TriggerableStage interface
+#include "../triggerable_stage.h"
 #include "snr_analysis_types.h"
 #include <atomic>
 #include <map>

--- a/orc/core/stages/triggerable_stage.h
+++ b/orc/core/stages/triggerable_stage.h
@@ -1,0 +1,92 @@
+/*
+* File:        triggerable_stage.h
+ * Module:      orc-core/stages
+ * Purpose:     Triggerable interface for stages that can be manually executed
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include "../include/artifact.h"
+#include "../include/stage_parameter.h"
+#include "../include/observation_context.h"
+#include <memory>
+#include <vector>
+#include <map>
+#include <string>
+#include <variant>
+
+namespace orc
+{
+
+/**
+ * @brief Progress callback for triggerable stages
+ *
+ * @param current Current progress value (e.g., frames processed)
+ * @param total Total work to be done (e.g., total frames)
+ * @param message Status message describing current operation
+ */
+using TriggerProgressCallback = std::function<void(size_t current, size_t total, const std::string& message)>;
+
+/**
+ * @brief Triggerable interface for stages that can be manually executed
+ *
+ * Stages that implement this interface can be triggered from the GUI,
+ * causing them to process their entire input range and perform their action.
+ */
+class TriggerableStage {
+public:
+  virtual ~TriggerableStage() = default;
+
+  /**
+   * @brief Trigger the stage to process its input
+   *
+   * For sinks, this means reading all fields from input and writing to output file.
+   *
+   * @param inputs Input artifacts (typically one VideoFieldRepresentation)
+   * @param parameters Stage parameters
+   * @return True if trigger succeeded, false otherwise
+   */
+  virtual bool trigger(
+      const std::vector<ArtifactPtr>& inputs,
+      const std::map<std::string, ParameterValue>& parameters,
+      ObservationContext& observation_context
+  ) = 0;
+
+  /**
+   * @brief Get status message after trigger
+   * @return Status message describing what was done
+   */
+  virtual std::string get_trigger_status() const = 0;
+
+  /**
+   * @brief Set progress callback for long-running trigger operations
+   *
+   * @param callback Function to call with progress updates (current, total, message)
+   */
+  virtual void set_progress_callback(TriggerProgressCallback callback) {
+   (void)callback; // Default implementation does nothing
+  }
+
+  /**
+   * @brief Check if trigger is currently in progress
+   * @return True if trigger is running, false otherwise
+   */
+  virtual bool is_trigger_in_progress() const {
+   return false; // Default implementation assumes no async operation
+  }
+
+  /**
+   * @brief Cancel an in-progress trigger operation
+   *
+   * Only relevant for stages that support async trigger operations.
+   * Default implementation does nothing.
+   */
+  virtual void cancel_trigger() {
+   // Default implementation does nothing
+  }
+};
+
+}

--- a/orc/presenters/src/project_presenter.cpp
+++ b/orc/presenters/src/project_presenter.cpp
@@ -14,7 +14,8 @@
 #include <orc_source_parameters.h>
 #include "../core/include/stage_parameter.h"
 #include "../core/include/logging.h"
-#include "../core/stages/ld_sink/ld_sink_stage.h"  // For TriggerableStage definition
+#include "../core/stages/triggerable_stage.h"
+#include "../core/tbc_source_internal/tbc_metadata.h"   // for TBCMetaDataReader
 #include <stdexcept>
 #include <algorithm>
 

--- a/orc/presenters/src/render_presenter.cpp
+++ b/orc/presenters/src/render_presenter.cpp
@@ -18,7 +18,7 @@
 #include "../core/include/vbi_decoder.h"
 #include "../core/include/observation_context.h"
 #include "../core/include/observation_cache.h"
-#include "../core/stages/ld_sink/ld_sink_stage.h"
+#include "../core/stages/triggerable_stage.h"
 #include "../core/stages/dropout_analysis_sink/dropout_analysis_sink_stage.h"
 #include "../core/stages/snr_analysis_sink/snr_analysis_sink_stage.h"
 #include "../core/stages/burst_level_analysis_sink/burst_level_analysis_sink_stage.h"


### PR DESCRIPTION
## Summary

The TriggerableStage interface was inside of the ld_sink_stage.h, probably because that was the first triggerable stage created.  It's not specific to ld_sink_stage so it should probably live in its own independent file.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Other

## Validation

I tested it by building everything and making sure the build didn't break :)

## Checklist

- [X] Scope is focused and minimal
- [X] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)

## Related issue

Closes #