### PR TITLE
Increasing encapsulation and testability

### DIFF
--- a/orc/core/CMakeLists.txt
+++ b/orc/core/CMakeLists.txt
@@ -15,7 +15,10 @@ add_library(orc-core STATIC
     
     # Logging
     logging.cpp
-    
+
+    # Abstract factories
+    factories.cpp
+
     # Crash handler
     crash_handler.cpp
     

--- a/orc/core/factories.cpp
+++ b/orc/core/factories.cpp
@@ -1,0 +1,26 @@
+/*
+* File:        factories.h
+ * Module:      orc-core
+ * Purpose:     Implement abstract factory design pattern ( https://en.wikipedia.org/wiki/Abstract_factory_pattern ) to
+ *                  a) encourage encapsulation in the architecture and
+ *                  b) make mocking in unit tests easier
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Matt Ownby
+ */
+
+#include "factories.h"
+#include "buffered_file_io.h"
+
+namespace orc
+{
+    std::unique_ptr<IFileWriter<uint8_t>> Factories::create_instance_buffered_file_writer_uint8(size_t buffer_size)
+    {
+        return std::make_unique<BufferedFileWriter<uint8_t>>(buffer_size);
+    }
+
+    std::unique_ptr<IFileWriter<uint16_t>> Factories::create_instance_buffered_file_writer_uint16(size_t buffer_size)
+    {
+        return std::make_unique<BufferedFileWriter<uint16_t>>(buffer_size);
+    }
+}

--- a/orc/core/factories.h
+++ b/orc/core/factories.h
@@ -1,0 +1,39 @@
+/*
+* File:        factories.h
+ * Module:      orc-core
+ * Purpose:     Implement abstract factory design pattern ( https://en.wikipedia.org/wiki/Abstract_factory_pattern ) to
+ *                  a) encourage encapsulation in the architecture and
+ *                  b) make mocking in unit tests easier
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Matt Ownby
+ */
+
+#ifndef DECODE_ORC_ROOT_FACTORIES_H
+#define DECODE_ORC_ROOT_FACTORIES_H
+#include "factories_interface.h"
+
+namespace orc
+{
+    /**
+     * @brief Concrete implementation of IFactories interface.
+     *
+     * Purpose: Increase encapsulation and testability
+     */
+    class Factories : public IFactories
+    {
+    public:
+
+        /**
+         * @brief Create instance of BufferedFileWriter<uint8_t>
+         */
+        std::unique_ptr<IFileWriter<uint8_t>> create_instance_buffered_file_writer_uint8(size_t buffer_size) override;
+
+        /**
+         * @brief Create instance of BufferedFileWriter<uint16_t>
+         */
+        std::unique_ptr<IFileWriter<uint16_t>> create_instance_buffered_file_writer_uint16(size_t buffer_size) override;
+    };
+} // orc
+
+#endif //DECODE_ORC_ROOT_FACTORIES_H

--- a/orc/core/factories_interface.h
+++ b/orc/core/factories_interface.h
@@ -1,0 +1,41 @@
+/*
+* File:        factories_interface.h
+ * Module:      orc-core
+ * Purpose:     Implement abstract factory design pattern ( https://en.wikipedia.org/wiki/Abstract_factory_pattern ) to
+ *                  a) encourage encapsulation in the architecture and
+ *                  b) make mocking in unit tests easier
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Matt Ownby
+ */
+
+#ifndef DECODE_ORC_ROOT_FACTORIES_INTERFACE_H
+#define DECODE_ORC_ROOT_FACTORIES_INTERFACE_H
+#include <memory>
+
+#include "include/file_io_interface.h"
+
+namespace orc
+{
+ /**
+  * @brief Interface containing abstract factory methods.
+  *
+  * Purpose: To increase encapsulation and testability.
+  */
+ class IFactories
+ {
+ public:
+
+  virtual ~IFactories() = default;
+
+  /*
+   * Factory methods for BufferedFileWriter.
+   * Since template methods cannot be virtual, we must define factory methods for each type that we need.
+   */
+
+  virtual std::unique_ptr<IFileWriter<uint8_t>> create_instance_buffered_file_writer_uint8(size_t buffer_size) = 0;
+  virtual std::unique_ptr<IFileWriter<uint16_t>> create_instance_buffered_file_writer_uint16(size_t buffer_size) = 0;
+ };
+} // orc
+
+#endif //DECODE_ORC_ROOT_FACTORIES_INTERFACE_H

--- a/orc/core/include/buffered_file_io.h
+++ b/orc/core/include/buffered_file_io.h
@@ -16,6 +16,8 @@
 #include <cstring>
 #include <stdexcept>
 
+#include "file_io_interface.h"
+
 namespace orc {
 
 /**
@@ -27,7 +29,7 @@ namespace orc {
  * Template parameter T is the data type being written (e.g., uint16_t, int16_t, uint8_t)
  */
 template<typename T>
-class BufferedFileWriter {
+class BufferedFileWriter : public IFileWriter<T> {
 public:
     /**
      * @brief Construct a buffered writer
@@ -46,7 +48,8 @@ public:
     /**
      * @brief Destructor - automatically flushes and closes
      */
-    ~BufferedFileWriter() {
+    ~BufferedFileWriter() override
+    {
         if (is_open_) {
             try {
                 close();
@@ -71,7 +74,8 @@ public:
      * @return true if opened successfully
      */
     bool open(const std::string& filepath, 
-              std::ios::openmode mode = std::ios::binary | std::ios::trunc) {
+              std::ios::openmode mode = std::ios::binary | std::ios::trunc) override
+    {
         if (is_open_) {
             close();
         }
@@ -94,7 +98,8 @@ public:
      * @param data Pointer to data
      * @param count Number of elements to write
      */
-    void write(const T* data, size_t count) {
+    void write(const T* data, size_t count) override
+    {
         if (!is_open_) {
             throw std::runtime_error("BufferedFileWriter: File not open");
         }
@@ -123,7 +128,8 @@ public:
      * @brief Write a vector of data
      * @param data Vector of data to write
      */
-    void write(const std::vector<T>& data) {
+    void write(const std::vector<T>& data) override
+    {
         if (!data.empty()) {
             write(data.data(), data.size());
         }
@@ -132,7 +138,8 @@ public:
     /**
      * @brief Flush buffered data to disk
      */
-    void flush() {
+    void flush() override
+    {
         if (!is_open_) {
             throw std::runtime_error("BufferedFileWriter: File not open");
         }
@@ -155,7 +162,8 @@ public:
     /**
      * @brief Close the file (automatically flushes)
      */
-    void close() {
+    void close() override
+    {
         if (!is_open_) {
             return;
         }
@@ -168,7 +176,8 @@ public:
     /**
      * @brief Get total bytes written to file
      */
-    uint64_t bytes_written() const {
+    uint64_t bytes_written() const override
+    {
         return bytes_written_;
     }
 
@@ -182,14 +191,16 @@ public:
     /**
      * @brief Check if file is open
      */
-    bool is_open() const {
+    bool is_open() const override
+    {
         return is_open_;
     }
 
     /**
      * @brief Get the filepath
      */
-    const std::string& filepath() const {
+    const std::string& filepath() const override
+    {
         return filepath_;
     }
 

--- a/orc/core/include/file_io_interface.h
+++ b/orc/core/include/file_io_interface.h
@@ -1,0 +1,81 @@
+/*
+* File:        file_io_interface.h
+ * Module:      orc-core
+ * Purpose:     Interface(s) for file I/O to make unit testing easier
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#ifndef DECODE_ORC_ROOT_FILE_IO_INTERFACE_H
+#define DECODE_ORC_ROOT_FILE_IO_INTERFACE_H
+
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace orc
+{
+    /**
+     * @brief Interface for file writer
+     *
+     * Purpose: To make mocking within unit-tests easier
+     *
+     * Template parameter T is the data type being written (e.g., uint16_t, int16_t, uint8_t)
+     */
+    template<typename T>
+    class IFileWriter
+    {
+    public:
+        virtual ~IFileWriter() = default;
+
+        /**
+         * @brief Open a file for buffered writing
+         * @param filepath Path to output file
+         * @param mode Open mode flags (default: binary | trunc)
+         * @return true if opened successfully
+         */
+        virtual bool open(const std::string& filepath, std::ios::openmode mode = std::ios::binary | std::ios::trunc) = 0;
+
+        /**
+         * @brief Write data to buffer (will auto-flush when buffer is full)
+         * @param data Pointer to data
+         * @param count Number of elements to write
+         */
+        virtual void write(const T* data, size_t count) = 0;
+
+        /**
+         * @brief Write a vector of data
+         * @param data Vector of data to write
+         */
+        virtual void write(const std::vector<T>& data) = 0;
+
+        /**
+         * @brief Flush buffered data to disk
+         */
+        virtual void flush() = 0;
+
+        /**
+         * @brief Close the file (automatically flushes)
+         */
+        virtual void close() = 0;
+
+        /**
+         * @brief Get total bytes written to file
+         */
+        virtual uint64_t bytes_written() const = 0;
+
+        /**
+         * @brief Check if file is open
+         */
+        virtual bool is_open() const = 0;
+
+        /**
+         * @brief Get the filepath
+         */
+        virtual const std::string& filepath() const = 0;
+    };
+}
+
+#endif //DECODE_ORC_ROOT_FILE_IO_INTERFACE_H

--- a/orc/core/include/observation_context.h
+++ b/orc/core/include/observation_context.h
@@ -15,24 +15,11 @@
 #include <vector>
 #include <variant>
 #include <optional>
-#include <cstdint>
+
+#include "observation_context_interface.h"
 #include "observation_schema.h"
 
 namespace orc {
-
-/**
- * @brief Type-safe observation value
- * 
- * Observations can be various types depending on what is being measured.
- * This variant covers common observation data types.
- */
-using ObservationValue = std::variant<
-    int32_t,           // Integer values (e.g., picture number, chapter)
-    int64_t,           // Large integer values (e.g., field sequence numbers)
-    double,            // Floating point values (e.g., burst level, SNR)
-    std::string,       // String values (e.g., timecode, text, confidence levels)
-    bool               // Boolean values (e.g., flag present/absent)
->;
 
 /**
  * @brief Pipeline-scoped observation storage
@@ -54,7 +41,7 @@ using ObservationValue = std::variant<
  *     int32_t picture_number = std::get<int32_t>(*pn);
  * }
  */
-class ObservationContext {
+class ObservationContext : public IObservationContext {
 public:
     ObservationContext() = default;
     
@@ -69,7 +56,7 @@ public:
     void set(FieldID field_id, 
              const std::string& namespace_, 
              const std::string& key, 
-             const ObservationValue& value);
+             const ObservationValue& value) override;
     
     /**
      * @brief Get an observation value for a specific field
@@ -81,7 +68,7 @@ public:
      */
     std::optional<ObservationValue> get(FieldID field_id,
                                         const std::string& namespace_, 
-                                        const std::string& key) const;
+                                        const std::string& key) const override;
     
     /**
      * @brief Check if an observation exists for a specific field
@@ -93,7 +80,7 @@ public:
      */
     bool has(FieldID field_id,
              const std::string& namespace_, 
-             const std::string& key) const;
+             const std::string& key) const override;
     
     /**
      * @brief Get all observation keys for a field in a namespace
@@ -103,7 +90,7 @@ public:
      * @return Vector of observation keys
      */
     std::vector<std::string> get_keys(FieldID field_id,
-                                      const std::string& namespace_) const;
+                                      const std::string& namespace_) const override;
     
     /**
      * @brief Get all namespaces that have observations for a field
@@ -111,7 +98,7 @@ public:
      * @param field_id Field identifier
      * @return Vector of namespace names
      */
-    std::vector<std::string> get_namespaces(FieldID field_id) const;
+    std::vector<std::string> get_namespaces(FieldID field_id) const override;
     
     /**
      * @brief Get all observations for a specific field
@@ -120,21 +107,21 @@ public:
      * @return Map of namespace -> (key -> value)
      */
     std::map<std::string, std::map<std::string, ObservationValue>> 
-    get_all_observations(FieldID field_id) const;
+    get_all_observations(FieldID field_id) const override;
     
     /**
      * @brief Clear all observations
      * 
      * Should be called when starting a new processing run.
      */
-    void clear();
+    void clear() override;
     
     /**
      * @brief Clear observations for a specific field
      * 
      * @param field_id Field identifier
      */
-    void clear_field(FieldID field_id);
+    void clear_field(FieldID field_id) override;
 
     /**
      * @brief Register observation schema entries to enable type validation
@@ -146,12 +133,12 @@ public:
      * data), but if a key exists in the schema and the type mismatches,
      * set() will throw std::invalid_argument.
      */
-    void register_schema(const std::vector<ObservationKey>& keys);
+    void register_schema(const std::vector<ObservationKey>& keys) override;
 
     /**
      * @brief Clear all registered schema entries
      */
-    void clear_schema();
+    void clear_schema() override;
 
 private:
     // Storage: field_id -> namespace -> key -> value

--- a/orc/core/include/observation_context_interface.h
+++ b/orc/core/include/observation_context_interface.h
@@ -1,0 +1,162 @@
+/*
+* File:        observation_context_interface.h
+ * Module:      orc-core
+ * Purpose:     Pipeline-scoped observation storage
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#ifndef DECODE_ORC_ROOT_OBSERVATION_CONTEXT_INTERFACE_H
+#define DECODE_ORC_ROOT_OBSERVATION_CONTEXT_INTERFACE_H
+
+#include <field_id.h>
+#include <string>
+#include <map>
+#include <vector>
+#include <variant>
+#include <optional>
+#include <cstdint>
+
+#include "observation_schema.h"
+
+namespace orc
+{
+    /**
+     * @brief Type-safe observation value
+     *
+     * Observations can be various types depending on what is being measured.
+     * This variant covers common observation data types.
+     */
+    using ObservationValue = std::variant<
+        int32_t,           // Integer values (e.g., picture number, chapter)
+        int64_t,           // Large integer values (e.g., field sequence numbers)
+        double,            // Floating point values (e.g., burst level, SNR)
+        std::string,       // String values (e.g., timecode, text, confidence levels)
+        bool               // Boolean values (e.g., flag present/absent)
+    >;
+
+    /**
+     * @brief Interface for ObservationContext.
+     *
+     * Purpose: To increase encapsulation and make mocking within unit tests easier
+     *
+     * ObservationContext stores typed, namespaced observations collected
+     * throughout pipeline execution. It flows alongside the VFR through
+     * all stages.
+     *
+     * Namespaces prevent collisions between different observer types.
+     * Keys within a namespace identify specific data fields.
+     *
+     * Observations are stored per-field to support field-level metadata.
+     *
+     * @example
+     * ObservationContext context;
+     * context.set(field_id, "biphase", "picture_number", 12345);
+     * auto pn = context.get(field_id, "biphase", "picture_number");
+     * if (pn && std::holds_alternative<int32_t>(*pn)) {
+     *     int32_t picture_number = std::get<int32_t>(*pn);
+     * }
+     */
+    class IObservationContext {
+    public:
+        virtual ~IObservationContext() = default;
+
+        /**
+         * @brief Set an observation value for a specific field
+         *
+         * @param field_id Field identifier
+         * @param namespace_ Namespace (typically observer type, e.g., "biphase", "vitc")
+         * @param key Observation key (e.g., "picture_number", "timecode")
+         * @param value Observation value
+         */
+        virtual void set(FieldID field_id,
+                         const std::string& namespace_,
+                         const std::string& key,
+                         const orc::ObservationValue& value) = 0;
+
+        /**
+         * @brief Get an observation value for a specific field
+         *
+         * @param field_id Field identifier
+         * @param namespace_ Namespace
+         * @param key Observation key
+         * @return Observation value if present, std::nullopt otherwise
+         */
+        virtual std::optional<ObservationValue> get(FieldID field_id,
+                                                    const std::string& namespace_,
+                                                    const std::string& key) const = 0;
+
+        /**
+         * @brief Check if an observation exists for a specific field
+         *
+         * @param field_id Field identifier
+         * @param namespace_ Namespace
+         * @param key Observation key
+         * @return True if observation exists, false otherwise
+         */
+        virtual bool has(FieldID field_id,
+                         const std::string& namespace_,
+                         const std::string& key) const = 0;
+
+        /**
+         * @brief Get all observation keys for a field in a namespace
+         *
+         * @param field_id Field identifier
+         * @param namespace_ Namespace
+         * @return Vector of observation keys
+         */
+        virtual std::vector<std::string> get_keys(FieldID field_id,
+                                                  const std::string& namespace_) const = 0;
+
+        /**
+         * @brief Get all namespaces that have observations for a field
+         *
+         * @param field_id Field identifier
+         * @return Vector of namespace names
+         */
+        virtual std::vector<std::string> get_namespaces(FieldID field_id) const = 0;
+
+        /**
+         * @brief Get all observations for a specific field
+         *
+         * @param field_id Field identifier
+         * @return Map of namespace -> (key -> value)
+         */
+        virtual std::map<std::string, std::map<std::string, ObservationValue>>
+        get_all_observations(FieldID field_id) const = 0;
+
+        /**
+         * @brief Clear all observations
+         *
+         * Should be called when starting a new processing run.
+         */
+        virtual void clear() = 0;
+
+        /**
+         * @brief Clear observations for a specific field
+         *
+         * @param field_id Field identifier
+         */
+        virtual void clear_field(FieldID field_id) = 0;
+
+        /**
+         * @brief Register observation schema entries to enable type validation
+         *
+         * Stages should declare provided observations; the executor may
+         * aggregate and register them prior to execution. When a schema
+         * is registered, subsequent set() calls will be validated against
+         * the expected types. Unknown keys are allowed (to permit exploratory
+         * data), but if a key exists in the schema and the type mismatches,
+         * set() will throw std::invalid_argument.
+         */
+        virtual void register_schema(const std::vector<ObservationKey>& keys) = 0;
+
+        /**
+         * @brief Clear all registered schema entries
+         */
+        virtual void clear_schema() = 0;
+    };
+}
+
+#endif //DECODE_ORC_ROOT_OBSERVATION_CONTEXT_INTERFACE_H

--- a/orc/core/include/stage_registry.h
+++ b/orc/core/include/stage_registry.h
@@ -170,3 +170,15 @@ public:
             return std::make_shared<StageClass>(); \
         }); \
     }
+
+/**
+ * @brief Macro for explicit stage registration with factory interface.
+ *
+ * Purpose: Alternate approach that reduces blast radius while we contemplate whether we like this architecture.
+ */
+#define ORC_REGISTER_STAGE_WITH_FACTORIES(StageClass) \
+namespace { \
+static ::orc::StageRegistration _orc_stage_registration_##StageClass([]() { \
+return std::make_shared<StageClass>(std::make_unique<Factories>()); \
+}); \
+}

--- a/orc/core/stages/daphne_vbi_sink/daphne_vbi_sink_stage.cpp
+++ b/orc/core/stages/daphne_vbi_sink/daphne_vbi_sink_stage.cpp
@@ -16,16 +16,16 @@
 #include "logging.h"
 #include "biphase_observer.h"
 #include "white_flag_observer.h"
-#include <fstream>
 #include <filesystem>
 #include <algorithm>
 #include <memory>
+#include "../../factories.h"
 
 namespace orc
 {
 
 // Register stage with registry
-ORC_REGISTER_STAGE(DaphneVBISinkStage)
+ORC_REGISTER_STAGE_WITH_FACTORIES(DaphneVBISinkStage)
 
 // Force linker to include this object file
 void force_link_DaphneVBISinkStage() {}
@@ -186,14 +186,14 @@ bool DaphneVBISinkStage::write_vbi(
         ORC_LOG_DEBUG("Opening VBI file for writing: {}", final_vbi_path);
 
         // Open VBI file with buffered writer (1MB buffer chosen arbitrarily)
-        BufferedFileWriter<uint8_t> vbi_writer(1 * 1024 * 1024);
-        if (!vbi_writer.open(final_vbi_path)) {
+        std::unique_ptr<IFileWriter<uint8_t>> vbi_writer = factories_->create_instance_buffered_file_writer_uint8(1 * 1024 * 1024);
+        if (!vbi_writer->open(final_vbi_path)) {
             ORC_LOG_ERROR("Failed to open VBI file for writing: {}", final_vbi_path);
             return false;
         }
 
         // Create VBI writer instance (TODO : use abstract factory in the future?)
-        DaphneVBIWriterUtil vbi_writer_util(vbi_writer);
+        DaphneVBIWriterUtil vbi_writer_util(vbi_writer.get());
         vbi_writer_util.write_header();  // header is required at the beginning of .VBI file
 
         // Get video parameters
@@ -229,7 +229,7 @@ bool DaphneVBISinkStage::write_vbi(
         for (FieldID field_id : field_ids) {
             // Check for cancellation
             if (cancel_requested_.load()) {
-                vbi_writer.close();
+                vbi_writer->close();
                 ORC_LOG_WARN("DaphneVBISink: Export cancelled by user");
                 is_processing_.store(false);
                 return false;
@@ -248,7 +248,7 @@ bool DaphneVBISinkStage::write_vbi(
             }
 
             // Write observations to VBI file
-            vbi_writer_util.write_observations(field_id, observation_context);
+            vbi_writer_util.write_observations(field_id, &observation_context);
 
             fields_processed++;
 
@@ -267,7 +267,7 @@ bool DaphneVBISinkStage::write_vbi(
             }
         }
 
-        vbi_writer.close();
+        vbi_writer->close();
 
         ORC_LOG_DEBUG("Successfully exported {} fields", fields_processed);
         return true;

--- a/orc/core/stages/daphne_vbi_sink/daphne_vbi_sink_stage.h
+++ b/orc/core/stages/daphne_vbi_sink/daphne_vbi_sink_stage.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <functional>
 #include <atomic>
+#include <utility>
+#include "../../factories_interface.h"
 
 namespace orc
 {
@@ -40,7 +42,7 @@ namespace orc
  */
 class DaphneVBISinkStage : public DAGStage, public ParameterizedStage, public TriggerableStage {
 public:
-    DaphneVBISinkStage() = default;
+    DaphneVBISinkStage(std::unique_ptr<IFactories> factories) : factories_(std::move(factories)) {}
     ~DaphneVBISinkStage() override = default;
 
     // DAGStage interface
@@ -89,6 +91,7 @@ private:
     TriggerProgressCallback progress_callback_;  // Progress callback for trigger operations
     std::atomic<bool> is_processing_{false};
     std::atomic<bool> cancel_requested_{false};
+    std::unique_ptr<IFactories> factories_;
 
     // Helper methods
     bool write_vbi(

--- a/orc/core/stages/daphne_vbi_sink/daphne_vbi_writer_util.cpp
+++ b/orc/core/stages/daphne_vbi_sink/daphne_vbi_writer_util.cpp
@@ -16,18 +16,18 @@ namespace orc
 void DaphneVBIWriterUtil::write_header() const
 {
     constexpr uint8_t arrHeader[4] = { '1', 'V', 'B', 'I' };
-    writer_.write(arrHeader, sizeof(arrHeader));
+    pWriter_->write(arrHeader, sizeof(arrHeader));
 }
 
 void DaphneVBIWriterUtil::write_observations(FieldID field_id,
-                                        const ObservationContext& context) const
+                                        const IObservationContext *pContext) const
 {
     VbiData vbi;
     bool whiteFlagPresent = false;
     uint8_t line_buf[10];  // each entry is 10-bytes in size
 
     // grab whiteflag data
-    auto whiteflag_obs = context.get(field_id, "white_flag", "present");
+    auto whiteflag_obs = pContext->get(field_id, "white_flag", "present");
     if (whiteflag_obs && std::holds_alternative<bool>(*whiteflag_obs))
     {
         whiteFlagPresent = std::get<bool>(*whiteflag_obs);
@@ -35,9 +35,9 @@ void DaphneVBIWriterUtil::write_observations(FieldID field_id,
 
     // Extract and write VBI data (from BiphaseObserver)
     // The biphase observer stores the raw VBI words in "biphase" namespace
-    auto vbi0_obs = context.get(field_id, "biphase", "vbi_line_16");
-    auto vbi1_obs = context.get(field_id, "biphase", "vbi_line_17");
-    auto vbi2_obs = context.get(field_id, "biphase", "vbi_line_18");
+    auto vbi0_obs = pContext->get(field_id, "biphase", "vbi_line_16");
+    auto vbi1_obs = pContext->get(field_id, "biphase", "vbi_line_17");
+    auto vbi2_obs = pContext->get(field_id, "biphase", "vbi_line_18");
 
     if (vbi0_obs && vbi1_obs && vbi2_obs &&
     std::holds_alternative<int32_t>(*vbi0_obs) &&
@@ -71,7 +71,7 @@ void DaphneVBIWriterUtil::write_observations(FieldID field_id,
         }
     }
 
-    writer_.write(line_buf, sizeof(line_buf));
+    pWriter_->write(line_buf, sizeof(line_buf));
 }
 
 }

--- a/orc/core/stages/daphne_vbi_sink/daphne_vbi_writer_util.h
+++ b/orc/core/stages/daphne_vbi_sink/daphne_vbi_writer_util.h
@@ -25,14 +25,14 @@ namespace orc
 class DaphneVBIWriterUtil
 {
 public:
-    DaphneVBIWriterUtil(BufferedFileWriter<uint8_t>& writer) : writer_(writer) {}
+    DaphneVBIWriterUtil(IFileWriter<uint8_t> *pWriter) : pWriter_(pWriter) {}
     ~DaphneVBIWriterUtil() = default;
 
     void write_header() const;
-    void write_observations(FieldID field_id, const ObservationContext& context) const;
+    void write_observations(FieldID field_id, const IObservationContext *pContext) const;
 
 private:
-    BufferedFileWriter<uint8_t>& writer_;
+    IFileWriter<uint8_t> *pWriter_;
 };
 
 }


### PR DESCRIPTION
## Summary

This PR put interfaces in front of a few common classes and adds an abstract factory interface/class as preferred alternative to just instantiating classes inside of other classes.  See changes to 'daphne_vbi_stink_stage.cpp' to see tightly-coupled method of instantiating the BufferedFileWriter class (the old way) vs abstract/loosely-coupled way to abstract the same class (the new way).

The benefits are classes such as DaphneVBIWriterUtil now depend on an interface (IFileWriter) instead of a concrete class so this IFileWriter interface can easily be mocked out in a unit test, which means the test can run without the file system ever being touched.  These types of test run much faster with no side effects so one could have a suite of hundreds of tests that execute in just a few seconds.

All dependencies of DaphneVBIWriterUtil are now abstract, making it much easier to unit test this class.

I took some guesses on the convention that you'd want file for names and class names.  I like putting 'I' in front of interfaces, but don't feel super strongly about it.

I didn't make all of the changes I could've made.  I just made enough to give you an idea of what the changes look like so you can decide how you feel about it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation
- [ ] Other

## Validation

I created a .TBC source and re-generated a .VBI file and manually confirmed that it still works.
If you are okay with this architectural direction, then I'll add some real unit tests next.

## Checklist

- [X] Scope is focused and minimal
- [X] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)

## Related issue

Closes #