### PR TITLE
Added support for loading JSON metadata as a fallback from SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ nix build
 nix run .#orc-gui
 ```
 
+Note that, if you want to pass command line options when using "nix run" it is performed using a command like:
+
+```
+nix run git+file:///home/pathtoproject/decode-orc#orc-gui -- --log-level debug --log-file /tmp/orc-gui.log
+```
+
 See [docs/NIX-BUILD.md](docs/NIX-BUILD.md) for complete Nix build instructions.
 
 ### Traditional Build

--- a/orc/CMakeLists.txt
+++ b/orc/CMakeLists.txt
@@ -83,7 +83,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/MVPEnforcement.cmake)
 # Common types (shared across all layers)
 add_subdirectory(common)
 
-# Core library (internal implementation)
+# Core library (internal implementation; includes metadata as a sub-library)
 add_subdirectory(core)
 
 # View types (shared data structures for presentation layer)

--- a/orc/core/CMakeLists.txt
+++ b/orc/core/CMakeLists.txt
@@ -43,7 +43,6 @@ add_library(orc-core STATIC
     
     # TBC file I/O
     tbc_reader.cpp
-    tbc_metadata.cpp
     tbc_source_internal/tbc_audio_efm_handler.cpp
     tbc_video_field_representation.cpp
     tbc_yc_video_field_representation.cpp
@@ -102,7 +101,6 @@ add_library(orc-core STATIC
     stages/pal_yc_source/pal_yc_source_stage.cpp
     stages/ntsc_yc_source/ntsc_yc_source_stage.cpp
     stages/ld_sink/ld_sink_stage.cpp
-    stages/ld_sink/tbc_metadata_writer.cpp
     stages/hackdac_sink/hackdac_sink_stage.cpp
     stages/dropout_correct/dropout_correct_stage.cpp
     stages/dropout_map/dropout_map_stage.cpp
@@ -202,8 +200,16 @@ target_include_directories(orc-core PUBLIC
 # Note: All include directories above are PRIVATE by default
 # =============================================================================
 
+# Metadata I/O library (SQLite reader/writer; sub-library of orc-core)
+add_subdirectory(metadata)
+
 # Link against common types
 target_link_libraries(orc-core PUBLIC orc-common)
+
+# Link against metadata library (SQLite reader/writer)
+# PUBLIC so that orc-presenters (which already uses TBCMetadataReader) continues
+# to see tbc_metadata.h.
+target_link_libraries(orc-core PUBLIC orc-metadata)
 
 # Link fmt (used by EFM decoder pipeline sources compiled directly into orc-core)
 target_link_libraries(orc-core PUBLIC fmt::fmt)

--- a/orc/core/metadata/CMakeLists.txt
+++ b/orc/core/metadata/CMakeLists.txt
@@ -1,0 +1,61 @@
+# orc-metadata: TBC metadata reader and writer
+#
+# This static library owns all metadata I/O for decode-orc.
+#   TBCMetadataSqliteReader  — reads .tbc.db (SQLite) files
+#   TBCMetadataJsonReader    — reads legacy .tbc.json files directly
+#   TBCMetadataWriter        — writes .tbc.db files
+#
+# Legacy JSON parsing uses LdDecodeMetaData (dropouts/jsonio/lddecodemetadata)
+# to parse .tbc.json into C++ structures; no SQLite intermediate step is used.
+#
+# Dependency direction:  orc-common  <-- orc-metadata  <-- orc-core
+# SQLite is an implementation detail, linked PRIVATE.
+
+add_library(orc-metadata STATIC
+    tbc_metadata.cpp
+    tbc_metadata_writer.cpp
+    tbc_metadata_json_reader.cpp
+    open_tbc_metadata.cpp
+    # Legacy JSON parsing sources
+    dropouts.cpp
+    jsonio.cpp
+    lddecodemetadata.cpp
+)
+
+target_include_directories(orc-metadata
+    # Public: consumers (orc-core) get tbc_metadata.h and tbc_metadata_writer.h
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/orc/metadata>
+        # view-types path is needed because tbc_metadata.h includes orc_source_parameters.h.
+        # Mirrors the pattern used in orc/core/CMakeLists.txt.
+        ${CMAKE_SOURCE_DIR}/orc/view-types
+
+    # Private: only needed when compiling orc-metadata's own sources
+    PRIVATE
+        # observation_context_interface.h, observation_schema.h, video_metadata_types.h
+        ${CMAKE_SOURCE_DIR}/orc/core/include
+        # JSON converter headers live alongside their .cpp files in this directory
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+find_package(SQLite3 REQUIRED)
+find_package(spdlog REQUIRED)
+
+target_link_libraries(orc-metadata
+    PUBLIC  orc-common              # field_id.h, common_types.h, spdlog (transitive)
+    PRIVATE SQLite::SQLite3         # SQLite is an implementation detail
+    PRIVATE spdlog::spdlog          # used by lddecodemetadata sources
+)
+
+# Match orc-core's compile-time spdlog filter level per build type.
+target_compile_definitions(orc-metadata PRIVATE
+    $<$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG>
+    $<$<NOT:$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>>:SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE>
+)
+
+# Install public headers
+install(DIRECTORY include/
+    DESTINATION include/orc/metadata
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/orc/core/metadata/dropouts.cpp
+++ b/orc/core/metadata/dropouts.cpp
@@ -1,0 +1,194 @@
+/************************************************************************
+
+    dropouts.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2018-2020 Simon Inns
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#include "dropouts.h"
+
+#include "jsonio.h"
+
+#include <cassert>
+#include <spdlog/spdlog.h>
+
+DropOuts::DropOuts(const std::vector<int32_t> &startx, const std::vector<int32_t> &endx, const std::vector<int32_t> &fieldLine)
+    : m_startx(startx), m_endx(endx), m_fieldLine(fieldLine)
+{
+}
+
+DropOuts::DropOuts(int reserve_size)
+    : m_startx(), m_endx(), m_fieldLine()
+{
+    reserve(reserve_size);
+}
+
+// Assignment '=' operator
+DropOuts& DropOuts::operator=(const DropOuts &inDropouts)
+{
+    // Do not allow assignment if both objects are the same
+    if (this != &inDropouts) {
+        // Copy the object's data
+        m_startx = inDropouts.m_startx;
+        m_endx = inDropouts.m_endx;
+        m_fieldLine = inDropouts.m_fieldLine;;
+    }
+
+    return *this;
+}
+
+// Append a dropout
+void DropOuts::append(const int32_t startx, const int32_t endx, const int32_t fieldLine)
+{
+    m_startx.push_back(startx);
+    m_endx.push_back(endx);
+    m_fieldLine.push_back(fieldLine);
+}
+
+void DropOuts::reserve(int size)
+{
+    m_startx.reserve(size);
+    m_endx.reserve(size);
+    m_fieldLine.reserve(size);
+}
+
+// Resize the size of the DropOuts record
+void DropOuts::resize(int32_t size)
+{
+    m_startx.resize(static_cast<size_t>(size));
+    m_endx.resize(static_cast<size_t>(size));
+    m_fieldLine.resize(static_cast<size_t>(size));
+}
+
+// Clear the DropOuts record
+void DropOuts::clear()
+{
+    m_startx.clear();
+    m_endx.clear();
+    m_fieldLine.clear();
+}
+
+// Method to concatenate dropouts on the same line that are close together
+// (to cut down on the amount of generated dropout data when processing noisy/bad sources)
+
+// TODO: Sort the DOs by fieldLine otherwise this won't work correctly unless the
+// caller is aware of the restriction (used in ld-diffdod only at the moment)
+void DropOuts::concatenate(const bool verbose)
+{
+    int32_t sizeAtStart = static_cast<int32_t>(m_startx.size());
+
+    // This variable controls the minimum allowed gap between dropouts
+    // if the gap between the end of the last dropout and the start of
+    // the next is less than minimumGap, the two dropouts will be
+    // concatenated together
+    int32_t minimumGap = 50;
+
+    // Start from dropout 1 as 0 has no previous dropout
+    int32_t i = 1;
+
+    while (i < static_cast<int32_t>(m_startx.size())) {
+        // Is the current dropout on the same frame line as the last?
+        if (m_fieldLine[static_cast<size_t>(i - 1)] == m_fieldLine[static_cast<size_t>(i)]) {
+            if ((m_endx[static_cast<size_t>(i - 1)] + minimumGap) > (m_startx[static_cast<size_t>(i)])) {
+                // Concatenate
+                m_endx[static_cast<size_t>(i - 1)] = m_endx[static_cast<size_t>(i)];
+
+                // Remove the current dropout
+                m_startx.erase(m_startx.begin() + i);
+                m_endx.erase(m_endx.begin() + i);
+                m_fieldLine.erase(m_fieldLine.begin() + i);
+            }
+        }
+
+        // Next dropout
+        i++;
+    }
+
+    if(verbose){spdlog::debug("Concatenated dropouts: was {} now {} dropouts", sizeAtStart, m_startx.size());}
+}
+
+// Read DropOuts from JSON
+void DropOuts::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "endx") readArray(reader, m_endx);
+        else if (member == "fieldLine") readArray(reader, m_fieldLine);
+        else if (member == "startx") readArray(reader, m_startx);
+        else reader.discard();
+    }
+
+    if (m_endx.size() != m_fieldLine.size() || m_endx.size() != m_startx.size()) {
+        reader.throwError("dropout array sizes do not match");
+    }
+
+    reader.endObject();
+}
+
+// Write DropOuts to JSON
+void DropOuts::write(JsonWriter &writer) const
+{
+    assert(!empty());
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("endx");
+    writeArray(writer, m_endx);
+    writer.writeMember("fieldLine");
+    writeArray(writer, m_fieldLine);
+    writer.writeMember("startx");
+    writeArray(writer, m_startx);
+
+    writer.endObject();
+}
+
+// Read an array of values from JSON
+void DropOuts::readArray(JsonReader &reader, std::vector<int32_t> &array)
+{
+    array.clear();
+
+    reader.beginArray();
+
+    while (reader.readElement()) {
+        int32_t value;
+        reader.read(value);
+        array.push_back(value);
+    }
+
+    reader.endArray();
+}
+
+// Write an array of values to JSON
+void DropOuts::writeArray(JsonWriter &writer, const std::vector<int32_t> &array) const
+{
+    writer.beginArray();
+
+    for (auto value : array) {
+        writer.writeElement();
+        writer.write(value);
+    }
+
+    writer.endArray();
+}

--- a/orc/core/metadata/dropouts.h
+++ b/orc/core/metadata/dropouts.h
@@ -1,0 +1,86 @@
+/************************************************************************
+
+    dropouts.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2018-2020 Simon Inns
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#ifndef DROPOUTS_H
+#define DROPOUTS_H
+
+#include <cstdint>
+#include <vector>
+
+class JsonReader;
+class JsonWriter;
+
+class DropOuts
+{
+public:
+    DropOuts() = default;
+    DropOuts(int reserve);
+    ~DropOuts() = default;
+    DropOuts(const DropOuts &) = default;
+
+    DropOuts(const std::vector<int32_t> &startx, const std::vector<int32_t> &endx, const std::vector<int32_t> &fieldLine);
+    DropOuts &operator=(const DropOuts &);
+
+    void append(const int32_t startx, const int32_t endx, const int32_t fieldLine);
+    void reserve(int size);
+    void resize(int32_t size);
+    void clear();
+    void concatenate(const bool verbose=true);
+
+    // Return the number of dropouts
+    int32_t size() const {
+        return static_cast<int32_t>(m_startx.size());
+    }
+
+    // Return true if there are no dropouts
+    bool empty() const {
+        return m_startx.empty();
+    }
+
+    // Get position of a dropout
+    int32_t startx(int32_t index) const {
+        return m_startx[static_cast<size_t>(index)];
+    }
+    int32_t endx(int32_t index) const {
+        return m_endx[static_cast<size_t>(index)];
+    }
+    int32_t fieldLine(int32_t index) const {
+        return m_fieldLine[static_cast<size_t>(index)];
+    }
+
+    void read(JsonReader &reader);
+    void write(JsonWriter &writer) const;
+
+private:
+    std::vector<int32_t> m_startx;
+    std::vector<int32_t> m_endx;
+    std::vector<int32_t> m_fieldLine;
+
+    void readArray(JsonReader &reader, std::vector<int32_t> &array);
+    void writeArray(JsonWriter &writer, const std::vector<int32_t> &array) const;
+};
+
+#endif // DROPOUTS_H

--- a/orc/core/metadata/include/itbc_metadata_reader.h
+++ b/orc/core/metadata/include/itbc_metadata_reader.h
@@ -1,0 +1,14 @@
+/*
+ * File:        itbc_metadata_reader.h
+ * Module:      orc-metadata
+ * Purpose:     ITBCMetadataReader interface — convenience include
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+// ITBCMetadataReader is defined inside tbc_metadata.h alongside the value types
+// it depends on.  Include that header to get both the interface and the types.
+#include <tbc_metadata.h>

--- a/orc/core/metadata/include/open_tbc_metadata.h
+++ b/orc/core/metadata/include/open_tbc_metadata.h
@@ -1,0 +1,34 @@
+/*
+ * File:        open_tbc_metadata.h
+ * Module:      orc-metadata
+ * Purpose:     Factory function for opening TBC metadata readers
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <itbc_metadata_reader.h>
+#include <memory>
+#include <string>
+
+namespace orc {
+
+/**
+ * @brief Open a TBC metadata reader for the given database path.
+ *
+ * Auto-detects the metadata format:
+ *  - If @p db_path exists as a SQLite .tbc.db file, returns a TBCMetadataSqliteReader.
+ *  - If @p db_path does not exist but a sibling .tbc.json file does, returns a
+ *    TBCMetadataJsonReader that converts the legacy JSON on-the-fly into an in-memory
+ *    SQLite database.
+ *  - Otherwise returns nullptr.
+ *
+ * @param db_path  Expected path to the .tbc.db (SQLite) metadata file.
+ * @return         An open ITBCMetadataReader, or nullptr if no metadata file was found
+ *                 or conversion failed.
+ */
+std::unique_ptr<ITBCMetadataReader> open_tbc_metadata(const std::string& db_path);
+
+} // namespace orc

--- a/orc/core/metadata/include/tbc_metadata.h
+++ b/orc/core/metadata/include/tbc_metadata.h
@@ -1,6 +1,6 @@
 /*
  * File:        tbc_metadata.h
- * Module:      orc-core
+ * Module:      orc-metadata
  * Purpose:     Tbc Metadata
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -10,10 +10,14 @@
 
 #pragma once
 
+// Forward-declare the SQLite handle so callers that only need open_from_handle
+// do not need to include <sqlite3.h>.
+struct sqlite3;
+
 #include <field_id.h>
 #include <common_types.h>  // For VideoSystem enum
 #include <orc_source_parameters.h>  // For SourceParameters
-#include "../include/video_metadata_types.h"  // For VbiData
+#include <video_metadata_types.h>  // For VbiData
 #include <string>
 #include <vector>
 #include <optional>
@@ -135,54 +139,95 @@ struct PcmAudioParameters {
 };
 
 /**
- * @brief Reader for TBC metadata (SQLite database)
- * 
+ * @brief Pure-virtual interface for TBC metadata readers
+ *
+ * Both TBCMetadataSqliteReader (Phase 1-3) and TBCMetadataJsonReader (Phase 4)
+ * implement this interface so callers can substitute either backend transparently.
+ */
+class ITBCMetadataReader {
+public:
+    virtual ~ITBCMetadataReader() = default;
+
+    virtual bool open(const std::string& filename) = 0;
+    virtual void close() = 0;
+    virtual bool is_open() const = 0;
+
+    virtual std::optional<SourceParameters> read_video_parameters() = 0;
+    virtual std::optional<PcmAudioParameters> read_pcm_audio_parameters() = 0;
+
+    virtual std::optional<FieldMetadata> read_field_metadata(FieldID field_id) = 0;
+    virtual std::map<FieldID, FieldMetadata> read_all_field_metadata() = 0;
+    virtual void read_all_dropouts() = 0;
+    virtual void preload_cache() = 0;
+
+    virtual std::optional<VbiData> read_vbi(FieldID field_id) = 0;
+    virtual std::optional<VitcData> read_vitc(FieldID field_id) = 0;
+    virtual std::optional<ClosedCaptionData> read_closed_caption(FieldID field_id) = 0;
+    virtual std::optional<DropoutData> read_dropout(FieldID field_id) const = 0;
+    virtual std::vector<DropoutInfo> read_dropouts(FieldID field_id) const = 0;
+
+    virtual int32_t get_field_record_count() const = 0;
+    virtual bool validate_metadata(std::string* error_message = nullptr) const = 0;
+};
+
+/**
+ * @brief SQLite-backed reader for TBC metadata
+ *
  * Based on legacy SqliteReader and LdDecodeMetaData classes.
  * Provides access to field metadata, VBI data, dropouts, etc.
  */
-class TBCMetadataReader {
+class TBCMetadataSqliteReader : public ITBCMetadataReader {
 public:
-    TBCMetadataReader();
-    ~TBCMetadataReader();
-    
+    TBCMetadataSqliteReader();
+    ~TBCMetadataSqliteReader() override;
+
     // Open a metadata database file
-    bool open(const std::string& filename);
-    void close();
-    
-    bool is_open() const { return is_open_; }
-    
+    bool open(const std::string& filename) override;
+
+    // Attach an already-open sqlite3 connection (takes ownership — the handle
+    // will be closed by close() / the destructor).  Used by TBCMetadataJsonReader
+    // to back a reader with an in-memory database.
+    bool open_from_handle(sqlite3* db);
+
+    void close() override;
+
+    bool is_open() const override { return is_open_; }
+
     // Read video parameters
-    std::optional<SourceParameters> read_video_parameters();
-    
+    std::optional<SourceParameters> read_video_parameters() override;
+
     // Read PCM audio parameters
-    std::optional<PcmAudioParameters> read_pcm_audio_parameters();
-    
+    std::optional<PcmAudioParameters> read_pcm_audio_parameters() override;
+
     // Read field metadata
-    std::optional<FieldMetadata> read_field_metadata(FieldID field_id);
-    
+    std::optional<FieldMetadata> read_field_metadata(FieldID field_id) override;
+
     // Read all field metadata (bulk operation)
-    std::map<FieldID, FieldMetadata> read_all_field_metadata();
-    void read_all_dropouts();  // Load all dropouts into cache
-    
+    std::map<FieldID, FieldMetadata> read_all_field_metadata() override;
+    void read_all_dropouts() override;
+
     // Preload all metadata and dropouts into cache
     // Call this when opening a project or adding a source stage to avoid lazy loading during analysis
-    void preload_cache();
-    
+    void preload_cache() override;
+
     // Read specific field data
-    std::optional<VbiData> read_vbi(FieldID field_id);
-    std::optional<VitcData> read_vitc(FieldID field_id);
-    std::optional<ClosedCaptionData> read_closed_caption(FieldID field_id);
-    std::optional<DropoutData> read_dropout(FieldID field_id) const;
-    std::vector<DropoutInfo> read_dropouts(FieldID field_id) const;  // Legacy compatibility
-    
+    std::optional<VbiData> read_vbi(FieldID field_id) override;
+    std::optional<VitcData> read_vitc(FieldID field_id) override;
+    std::optional<ClosedCaptionData> read_closed_caption(FieldID field_id) override;
+    std::optional<DropoutData> read_dropout(FieldID field_id) const override;
+    std::vector<DropoutInfo> read_dropouts(FieldID field_id) const override;
+
     // Validation and diagnostics
-    int32_t get_field_record_count() const;
-    bool validate_metadata(std::string* error_message = nullptr) const;
-    
+    int32_t get_field_record_count() const override;
+    bool validate_metadata(std::string* error_message = nullptr) const override;
+
 private:
     class Impl;  // Forward declaration for pimpl
     std::unique_ptr<Impl> impl_;
     bool is_open_;
 };
+
+// Backward-compatibility alias – prefer ITBCMetadataReader in new code
+using TBCMetadataReader = TBCMetadataSqliteReader;
 
 } // namespace orc

--- a/orc/core/metadata/include/tbc_metadata_json_reader.h
+++ b/orc/core/metadata/include/tbc_metadata_json_reader.h
@@ -1,0 +1,68 @@
+/*
+ * File:        tbc_metadata_json_reader.h
+ * Module:      orc-metadata
+ * Purpose:     JSON-backed TBC metadata reader (Phase 4)
+ *
+ * Reads legacy .tbc.json metadata produced by older ld-decode / vhs-decode
+ * versions directly into C++ data structures via LdDecodeMetaData.
+ * No SQLite intermediate database is required.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#pragma once
+
+#include <tbc_metadata.h>
+#include <map>
+#include <vector>
+#include <optional>
+#include <string>
+
+namespace orc {
+
+/**
+ * @brief ITBCMetadataReader implementation backed by a legacy JSON file.
+ *
+ * On open() the JSON is parsed directly by LdDecodeMetaData into C++ data
+ * structures stored in in-memory maps.  All reads are served from those maps;
+ * no SQLite is involved.
+ */
+class TBCMetadataJsonReader : public ITBCMetadataReader {
+public:
+    TBCMetadataJsonReader();
+    ~TBCMetadataJsonReader() override;
+
+    bool open(const std::string& json_path) override;
+    void close() override;
+    bool is_open() const override;
+
+    std::optional<SourceParameters>    read_video_parameters() override;
+    std::optional<PcmAudioParameters>  read_pcm_audio_parameters() override;
+
+    std::optional<FieldMetadata>             read_field_metadata(FieldID field_id) override;
+    std::map<FieldID, FieldMetadata>         read_all_field_metadata() override;
+    void                                     read_all_dropouts() override;
+    void                                     preload_cache() override;
+
+    std::optional<VbiData>           read_vbi(FieldID field_id) override;
+    std::optional<VitcData>          read_vitc(FieldID field_id) override;
+    std::optional<ClosedCaptionData> read_closed_caption(FieldID field_id) override;
+    std::optional<DropoutData>       read_dropout(FieldID field_id) const override;
+    std::vector<DropoutInfo>         read_dropouts(FieldID field_id) const override;
+
+    int32_t get_field_record_count() const override;
+    bool    validate_metadata(std::string* error_message = nullptr) const override;
+
+private:
+    bool is_open_ = false;
+    std::optional<SourceParameters>              source_params_;
+    std::optional<PcmAudioParameters>            audio_params_;
+    std::map<FieldID, FieldMetadata>             field_cache_;
+    std::map<FieldID, VbiData>                   vbi_cache_;
+    std::map<FieldID, VitcData>                  vitc_cache_;
+    std::map<FieldID, ClosedCaptionData>         cc_cache_;
+    std::map<FieldID, std::vector<DropoutInfo>>  dropout_cache_;
+};
+
+} // namespace orc

--- a/orc/core/metadata/include/tbc_metadata_writer.h
+++ b/orc/core/metadata/include/tbc_metadata_writer.h
@@ -1,6 +1,6 @@
 /*
  * File:        tbc_metadata_writer.h
- * Module:      orc-core
+ * Module:      orc-metadata
  * Purpose:     TBC Metadata Writer (SQLite)
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -9,10 +9,9 @@
 
 #pragma once
 
-#include "../../tbc_source_internal/tbc_metadata.h"
+#include "tbc_metadata.h"
 #include <field_id.h>
-#include "observer.h"
-#include "observation_context.h"
+#include <observation_context_interface.h>
 #include <string>
 #include <memory>
 #include <vector>
@@ -57,8 +56,8 @@ public:
     bool write_vits_metrics(FieldID field_id, const VitsMetrics& metrics);
     bool write_dropout(FieldID field_id, const DropoutInfo& dropout);
     
-    // Write all observations from an ObservationContext
-    bool write_observations(FieldID field_id, const ObservationContext& context);
+    // Write all observations from an IObservationContext
+    bool write_observations(FieldID field_id, const IObservationContext& context);
     
     // Transaction support for bulk writes
     bool begin_transaction();

--- a/orc/core/metadata/jsonio.cpp
+++ b/orc/core/metadata/jsonio.cpp
@@ -1,0 +1,473 @@
+/************************************************************************
+
+    jsonio.cpp
+
+    ld-decode-tools TBC library
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#include "jsonio.h"
+
+#include <limits>
+#if (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || (defined(__GNUC__) && __GNUC__ >= 11 && __cplusplus >= 201703L)
+#define USE_CHARCONV
+#endif
+#ifdef USE_CHARCONV
+#include <charconv>
+#else
+#include <sstream>
+#endif
+
+// Recognise JSON space characters
+static bool isAsciiSpace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+// Recognise JSON digit characters
+static bool isAsciiDigit(char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+JsonReader::JsonReader(std::istream &_input)
+    : input(_input), position(0), atStart(true)
+{
+}
+
+void JsonReader::read(int &value)
+{
+    readSignedInteger(value);
+}
+
+void JsonReader::read(int64_t &value)
+{
+    readSignedInteger(value);
+}
+
+void JsonReader::read(double &value)
+{
+    readNumber(value);
+}
+
+void JsonReader::read(bool &value)
+{
+    const char *rest;
+
+    char c = spaceGet();
+    if (c == 't') {
+        rest = "rue";
+    } else if (c == 'f') {
+        rest = "alse";
+    } else {
+        throwError("expected true or false");
+    }
+
+    while (*rest) {
+        if (get() != *rest++) throwError("expected true or false");
+    }
+
+    value = (c == 't');
+}
+
+void JsonReader::read(std::string &value)
+{
+    readString(value);
+}
+
+void JsonReader::beginObject()
+{
+    if (spaceGet() != '{') throwError("expected {");
+
+    atStarts.push(atStart);
+    atStart = true;
+}
+
+bool JsonReader::readMember(std::string &member)
+{
+    char c = spaceGet();
+    if (c == '}') {
+        // Found the end - don't consume the }
+        unget();
+        return false;
+    }
+    if (atStart) {
+        // Start of the first member - don't consume it
+        unget();
+    } else {
+        // Consume the ,
+        if (c != ',') throwError("expected , or }");
+    }
+
+    readString(member);
+
+    if (spaceGet() != ':') throwError("expected :");
+
+    atStart = false;
+    return true;
+}
+
+void JsonReader::endObject()
+{
+    if (spaceGet() != '}') throwError("expected }");
+
+    atStart = atStarts.top();
+    atStarts.pop();
+}
+
+void JsonReader::beginArray()
+{
+    if (spaceGet() != '[') throwError("expected [");
+
+    atStarts.push(atStart);
+    atStart = true;
+}
+
+bool JsonReader::readElement()
+{
+    char c = spaceGet();
+    if (c == ']') {
+        // Found the end - don't consume the ]
+        unget();
+        return false;
+    }
+    if (atStart) {
+        // Start of the first element - don't consume it
+        unget();
+    } else {
+        // Consume the ,
+        if (c != ',') throwError("expected , or ]");
+    }
+
+    atStart = false;
+    return true;
+}
+
+void JsonReader::endArray()
+{
+    if (spaceGet() != ']') throwError("expected ]");
+
+    atStart = atStarts.top();
+    atStarts.pop();
+}
+
+void JsonReader::discard()
+{
+    // Peek at the first character to see what type it is
+    char c = spaceGet();
+    unget();
+
+    if (c == '-' || isAsciiDigit(c)) {
+        double dummy;
+        readNumber(dummy);
+    } else if (c == 't' || c == 'f') {
+        bool dummy;
+        read(dummy);
+    } else if (c == '"') {
+        readString(buf);
+    } else if (c == '{') {
+        beginObject();
+        while (readMember(buf)) discard();
+        endObject();
+    } else if (c == '[') {
+        beginArray();
+        while (readElement()) discard();
+        endArray();
+    } else {
+        // XXX recognise null
+        throwError("unrecognised value");
+    }
+}
+
+// Get the next input character, returning 0 on EOF or error
+char JsonReader::get()
+{
+    char c;
+    input.get(c);
+    if (!input.good()) return 0;
+    ++position;
+    return c;
+}
+
+// Get the next input character, discarding spaces before it
+char JsonReader::spaceGet()
+{
+    char c;
+    do {
+        c = get();
+    } while (isAsciiSpace(c));
+    return c;
+}
+
+// Put back an input character to be read again
+void JsonReader::unget()
+{
+    // We assume the input stream supports unget.
+    // (If this becomes a problem in the future, we could simulate it.)
+    input.unget();
+    --position;
+}
+
+// Read a JSON string. The result is unescaped and doesn't include the quotes.
+void JsonReader::readString(std::string &value)
+{
+    char c = spaceGet();
+    if (c != '"') throwError("expected string");
+
+    value.clear();
+
+    while (true) {
+        c = get();
+        switch (c) {
+        case 0:
+            // End of input
+            throwError("end of input in string");
+        case '"':
+            // End of string
+            return;
+        case '\\':
+            c = get();
+            switch (c) {
+            case '"':
+            case '/':
+            case '\\':
+                value.push_back(c);
+                break;
+            case 'b':
+                value.push_back('\b');
+                break;
+            case 'f':
+                value.push_back('\f');
+                break;
+            case 'n':
+                value.push_back('\n');
+                break;
+            case 'r':
+                value.push_back('\r');
+                break;
+            case 't':
+                value.push_back('\t');
+                break;
+            case 'u':
+                throwError("\\u escapes not supported");
+            default:
+                throwError("unrecognised \\ escape");
+            }
+            break;
+        default:
+            value.push_back(c);
+            break;
+        }
+    }
+}
+
+// Read a JSON number
+void JsonReader::readNumber(double &value)
+{
+    // JSON only has "numbers"; it doesn't distinguish between floating point
+    // and integers. This means we have to parse as a double, since a value
+    // we're expecting to use as an integer might be written as 1.234e3 or
+    // similar.
+
+    // Check that the number matches JSON's number syntax, which is more
+    // restrictive than the C/C++ parsers accept.
+
+    // XXX could track if we only saw the int part, and parse straight to int
+
+    buf.clear();
+
+    char c = spaceGet();
+    if (c == '-') {
+        buf.push_back(c);
+        c = get();
+    }
+    if (!isAsciiDigit(c)) throwError("expected - or digit");
+    buf.push_back(c);
+    c = get();
+
+    while (isAsciiDigit(c)) {
+        buf.push_back(c);
+        c = get();
+    }
+
+    if (c == '.') {
+        buf.push_back(c);
+        c = get();
+        if (!isAsciiDigit(c)) throwError("expected digit after .");
+        buf.push_back(c);
+        while (true) {
+            c = get();
+            if (!isAsciiDigit(c)) break;
+            buf.push_back(c);
+        }
+    }
+
+    if (c == 'e') {
+        buf.push_back(c);
+        c = get();
+        if (c == '-' || c == '+') {
+            buf.push_back(c);
+            c = get();
+        }
+        if (!isAsciiDigit(c)) throwError("expected digit after e");
+        buf.push_back(c);
+        while (true) {
+            c = get();
+            if (!isAsciiDigit(c)) break;
+            buf.push_back(c);
+        }
+    }
+
+#ifdef USE_CHARCONV
+    // Use the faster C++17 method if available. 
+    // (Skip if clang is detected since it was late to implement, and thus not available on macos yet.)
+    std::from_chars(buf.data(), buf.data() + buf.size(), value);
+#else
+    std::istringstream(buf) >> value;
+#endif
+
+
+    // We've read one character beyond the end of the number (there's no way to
+    // tell where the end is otherwise), so we must unget the last char
+    unget();
+}
+
+JsonWriter::JsonWriter(std::ostream &_output)
+    : output(_output), atStart(true)
+{
+    // Use maximum double precision for floating-point output
+    output.precision(std::numeric_limits<double>::digits10 + 1);
+}
+
+void JsonWriter::write(int value)
+{
+    output << value;
+}
+
+void JsonWriter::write(int64_t value)
+{
+    output << value;
+}
+
+void JsonWriter::write(double value)
+{
+    output << value;
+}
+
+void JsonWriter::write(bool value)
+{
+    output << (value ? "true" : "false");
+}
+
+void JsonWriter::write(const char *value)
+{
+    writeString(value);
+}
+
+void JsonWriter::write(const std::string &value)
+{
+    writeString(value.c_str());
+}
+
+void JsonWriter::beginObject()
+{
+    output.put('{');
+
+    atStarts.push(atStart);
+    atStart = true;
+}
+
+void JsonWriter::writeMember(const char *member)
+{
+    if (!atStart) output.put(',');
+
+    writeString(member);
+    output << ":";
+
+    atStart = false;
+}
+
+void JsonWriter::endObject()
+{
+    output.put('}');
+
+    atStart = atStarts.top();
+    atStarts.pop();
+}
+
+void JsonWriter::beginArray()
+{
+    output.put('[');
+
+    atStarts.push(atStart);
+    atStart = true;
+}
+
+void JsonWriter::writeElement()
+{
+    if (!atStart) output.put(',');
+
+    atStart = false;
+}
+
+void JsonWriter::endArray()
+{
+    output.put(']');
+
+    atStart = atStarts.top();
+    atStarts.pop();
+}
+
+void JsonWriter::writeString(const char *str)
+{
+    output.put('"');
+
+    while (char c = *str++) {
+        switch (c) {
+        case '"':
+        case '\\':
+            output.put('\\');
+            output.put(c);
+            break;
+        case '\b':
+            output << "\\b";
+            break;
+        case '\f':
+            output << "\\f";
+            break;
+        case '\n':
+            output << "\\n";
+            break;
+        case '\r':
+            output << "\\r";
+            break;
+        case '\t':
+            output << "\\t";
+            break;
+        default:
+            output.put(c);
+            break;
+        }
+    }
+
+    output.put('"');
+}
+

--- a/orc/core/metadata/jsonio.h
+++ b/orc/core/metadata/jsonio.h
@@ -1,0 +1,149 @@
+/************************************************************************
+
+    jsonio.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2022 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#ifndef JSONIO_H
+#define JSONIO_H
+
+#include <cassert>
+#include <cstdint>
+#include <istream>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <stack>
+#include <cmath>
+
+class JsonReader
+{
+public:
+    JsonReader(std::istream &_input);
+
+    // Exception class to be thrown when parsing fails
+    class Error : public std::runtime_error
+    {
+    public:
+        Error(std::string message) : std::runtime_error(message) {}
+    };
+
+    // Throw an Error exception with the given message
+    [[noreturn]] void throwError(std::string message) {
+        throw Error(message + " at byte " + std::to_string(position));
+    }
+
+    // Numbers
+    void read(int64_t &value);
+    void read(int &value);
+    void read(double &value);
+
+    // Booleans
+    void read(bool &value);
+
+    // Strings
+    void read(std::string &value);
+
+    // Objects (each member followed by a value)
+    void beginObject();
+    bool readMember(std::string &member);
+    void endObject();
+
+    // Arrays (each element followed by a value)
+    void beginArray();
+    bool readElement();
+    void endArray();
+
+    // Read and discard the next value, whatever type it is
+    void discard();
+
+private:
+    char get();
+    char spaceGet();
+    void unget();
+
+    void readString(std::string &value);
+    void readNumber(double &value);
+    template <typename T> void readSignedInteger(T& value) {
+        // Round to the nearest integer
+        double d;
+        readNumber(d);
+        value = static_cast<T>(std::llround(d));
+    }
+
+    // The input stream
+    std::istream &input;
+    unsigned long position;
+
+    // True if we're at the start of a { or [ construct
+    bool atStart;
+    std::stack<bool> atStarts;
+
+    // Buffer for reading tokens, to minimise reallocations
+    std::string buf;
+};
+
+class JsonWriter
+{
+public:
+    JsonWriter(std::ostream &_output);
+
+    // Numbers
+    void write(int value);
+    void write(int64_t value);
+    void write(double value);
+
+    // Booleans
+    void write(bool value);
+
+    // Strings
+    void write(const char *value);
+    void write(const std::string &value);
+
+    // Objects (each member followed by a value)
+    void beginObject();
+    void writeMember(const char *name);
+    template <typename T>
+    void writeMember(const char *name, T value) {
+        writeMember(name);
+        write(value);
+    }
+    void endObject();
+
+    // Arrays (each element followed by a value)
+    void beginArray();
+    void writeElement();
+    void endArray();
+
+private:
+    void writeString(const char *str);
+
+    // The output stream
+    std::ostream &output;
+
+    // True if we're at the start of a [ or { construct
+    bool atStart;
+    std::stack<bool> atStarts;
+};
+
+#endif

--- a/orc/core/metadata/lddecodemetadata.cpp
+++ b/orc/core/metadata/lddecodemetadata.cpp
@@ -1,0 +1,1171 @@
+/************************************************************************
+
+    lddecodemetadata.cpp
+
+    ld-decode-tools TBC library
+    Copyright (C) 2018-2020 Simon Inns
+    Copyright (C) 2022 Ryan Holtz
+    Copyright (C) 2022-2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#include "lddecodemetadata.h"
+
+#include "jsonio.h"
+
+#include <cassert>
+#include <fstream>
+#include <spdlog/spdlog.h>
+
+// Default values used when configuring VideoParameters for a particular video system.
+struct VideoSystemDefaults {
+    LdVideoSystem system;
+    const char *name;
+    double fSC;
+    int32_t minActiveFrameLine;
+    int32_t firstActiveFieldLine;
+    int32_t lastActiveFieldLine;
+    int32_t firstActiveFrameLine;
+    int32_t lastActiveFrameLine;
+};
+
+static constexpr VideoSystemDefaults palDefaults {
+    LdVideoSystem::PAL,
+    "PAL",
+    (283.75 * 15625) + 25,
+    2,
+    22, 308,
+    44, 620,
+};
+
+static constexpr VideoSystemDefaults ntscDefaults {
+    LdVideoSystem::NTSC,
+    "NTSC",
+    315.0e6 / 88.0,
+    1,
+    20, 259,
+    40, 525,
+};
+
+static constexpr VideoSystemDefaults palMDefaults {
+    LdVideoSystem::PAL_M,
+    "PAL_M",
+    5.0e6 * (63.0 / 88.0) * (909.0 / 910.0),
+    ntscDefaults.minActiveFrameLine,
+    ntscDefaults.firstActiveFieldLine, ntscDefaults.lastActiveFieldLine,
+    ntscDefaults.firstActiveFrameLine, ntscDefaults.lastActiveFrameLine,
+};
+
+// These must be in the same order as enum VideoSystem
+static constexpr VideoSystemDefaults VIDEO_SYSTEM_DEFAULTS[] = {
+    palDefaults,
+    ntscDefaults,
+    palMDefaults,
+};
+
+// Return appropriate defaults for the selected video system
+static const VideoSystemDefaults &getSystemDefaults(const LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    return VIDEO_SYSTEM_DEFAULTS[static_cast<size_t>(videoParameters.system)];
+}
+
+// Look up a video system by name.
+// Return true and set system if found; if not found, return false.
+bool parseVideoSystemName(std::string name, LdVideoSystem &system)
+{
+    // Search VIDEO_SYSTEM_DEFAULTS for a matching name
+    for (const auto &defaults: VIDEO_SYSTEM_DEFAULTS) {
+        if (name == defaults.name) {
+            system = defaults.system;
+            return true;
+        }
+    }
+    return false;
+}
+
+// Read Vbi from JSON
+void LdDecodeMetaData::Vbi::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "vbiData") {
+            reader.beginArray();
+
+            // There should be exactly 3 values, but handle more or less
+            unsigned int i = 0;
+            while (reader.readElement()) {
+                int value;
+                reader.read(value);
+
+                if (i < vbiData.size()) vbiData[i++] = value;
+            }
+            while (i < vbiData.size()) vbiData[i++] = 0;
+
+            reader.endArray();
+        } else {
+            reader.discard();
+        }
+    }
+
+    reader.endObject();
+
+    inUse = true;
+}
+
+// Write Vbi to JSON
+void LdDecodeMetaData::Vbi::write(JsonWriter &writer) const
+{
+    assert(inUse);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("vbiData");
+    writer.beginArray();
+    for (auto value : vbiData) {
+        writer.writeElement();
+        writer.write(value);
+    }
+    writer.endArray();
+
+    writer.endObject();
+}
+
+// Read VideoParameters from JSON
+void LdDecodeMetaData::VideoParameters::read(JsonReader &reader)
+{
+    bool isSourcePal = false;
+    std::string systemString = "";
+
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "activeVideoEnd") reader.read(activeVideoEnd);
+        else if (member == "activeVideoStart") reader.read(activeVideoStart);
+        else if (member == "black16bIre") reader.read(black16bIre);
+        else if (member == "colourBurstEnd") reader.read(colourBurstEnd);
+        else if (member == "colourBurstStart") reader.read(colourBurstStart);
+        else if (member == "fieldHeight") reader.read(fieldHeight);
+        else if (member == "fieldWidth") reader.read(fieldWidth);
+        else if (member == "gitBranch") reader.read(gitBranch);
+        else if (member == "gitCommit") reader.read(gitCommit);
+        else if (member == "isMapped") reader.read(isMapped);
+        else if (member == "isSourcePal") reader.read(isSourcePal); // obsolete
+        else if (member == "isSubcarrierLocked") reader.read(isSubcarrierLocked);
+        else if (member == "isWidescreen") reader.read(isWidescreen);
+        else if (member == "numberOfSequentialFields") reader.read(numberOfSequentialFields);
+        else if (member == "sampleRate") reader.read(sampleRate);
+        else if (member == "system") reader.read(systemString);
+        else if (member == "white16bIre") reader.read(white16bIre);
+        else if (member == "tapeFormat") reader.read(tapeFormat);
+        else reader.discard();
+    }
+
+    reader.endObject();
+
+    // Work out which video system is being used
+    if (systemString == "") {
+        // Not specified -- detect based on isSourcePal and fieldHeight
+        if (isSourcePal) {
+            if (fieldHeight < 300) system = LdVideoSystem::PAL_M;
+            else system = LdVideoSystem::PAL;
+        } else system = LdVideoSystem::NTSC;
+    } else if (!parseVideoSystemName(systemString, system)) {
+        reader.throwError("unknown value for videoParameters.system");
+    }
+
+    isValid = true;
+}
+
+// Write VideoParameters to JSON
+void LdDecodeMetaData::VideoParameters::write(JsonWriter &writer) const
+{
+    assert(isValid);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("activeVideoEnd", activeVideoEnd);
+    writer.writeMember("activeVideoStart", activeVideoStart);
+    writer.writeMember("black16bIre", black16bIre);
+    writer.writeMember("colourBurstEnd", colourBurstEnd);
+    writer.writeMember("colourBurstStart", colourBurstStart);
+    writer.writeMember("fieldHeight", fieldHeight);
+    writer.writeMember("fieldWidth", fieldWidth);
+    if (!gitBranch.empty()) {
+        writer.writeMember("gitBranch", gitBranch);
+    }
+    if (!gitCommit.empty()) {
+        writer.writeMember("gitCommit", gitCommit);
+    }
+    writer.writeMember("isMapped", isMapped);
+    writer.writeMember("isSubcarrierLocked", isSubcarrierLocked);
+    writer.writeMember("isWidescreen", isWidescreen);
+    writer.writeMember("numberOfSequentialFields", numberOfSequentialFields);
+    writer.writeMember("sampleRate", sampleRate);
+    writer.writeMember("system", VIDEO_SYSTEM_DEFAULTS[static_cast<size_t>(system)].name);
+    writer.writeMember("white16bIre", white16bIre);
+	if(!tapeFormat.empty()) {
+		writer.writeMember("tapeFormat", tapeFormat);
+	}
+
+    writer.endObject();
+}
+
+// Read VitsMetrics from JSON
+void LdDecodeMetaData::VitsMetrics::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "bPSNR") reader.read(bPSNR);
+        else if (member == "wSNR") reader.read(wSNR);
+        else reader.discard();
+    }
+
+    reader.endObject();
+
+    inUse = true;
+}
+
+// Write VitsMetrics to JSON
+void LdDecodeMetaData::VitsMetrics::write(JsonWriter &writer) const
+{
+    assert(inUse);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("bPSNR", bPSNR);
+    writer.writeMember("wSNR", wSNR);
+
+    writer.endObject();
+}
+
+// Read Ntsc from JSON
+void LdDecodeMetaData::Ntsc::read(JsonReader &reader, ClosedCaption &closedCaption)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "isFmCodeDataValid") reader.read(isFmCodeDataValid);
+        else if (member == "fmCodeData") reader.read(fmCodeData);
+        else if (member == "fieldFlag") reader.read(fieldFlag);
+        else if (member == "isVideoIdDataValid") reader.read(isVideoIdDataValid);
+        else if (member == "videoIdData") reader.read(videoIdData);
+        else if (member == "whiteFlag") reader.read(whiteFlag);
+        else if (member == "ccData0") {
+            // rev7 and earlier put ccData0/1 here rather than in cc
+            reader.read(closedCaption.data0);
+            closedCaption.inUse = true;
+        } else if (member == "ccData1") {
+            reader.read(closedCaption.data1);
+            closedCaption.inUse = true;
+        } else {
+            reader.discard();
+        }
+    }
+
+    reader.endObject();
+
+    inUse = true;
+}
+
+// Write Ntsc to JSON
+void LdDecodeMetaData::Ntsc::write(JsonWriter &writer) const
+{
+    assert(inUse);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    if (isFmCodeDataValid) {
+        writer.writeMember("fieldFlag", fieldFlag);
+    }
+    if (isFmCodeDataValid) {
+        writer.writeMember("fmCodeData", fmCodeData);
+    }
+    writer.writeMember("isFmCodeDataValid", isFmCodeDataValid);
+    if (isVideoIdDataValid) {
+        writer.writeMember("videoIdData", videoIdData);
+    }
+    writer.writeMember("isVideoIdDataValid", isVideoIdDataValid);
+    if (whiteFlag) {
+        writer.writeMember("whiteFlag", whiteFlag);
+    }
+
+    writer.endObject();
+}
+
+// Read Vitc from JSON
+void LdDecodeMetaData::Vitc::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "vitcData") {
+            reader.beginArray();
+
+            // There should be exactly 8 values, but handle more or less
+            unsigned int i = 0;
+            while (reader.readElement()) {
+                int value;
+                reader.read(value);
+
+                if (i < vitcData.size()) vitcData[i++] = value;
+            }
+            while (i < vitcData.size()) vitcData[i++] = 0;
+
+            reader.endArray();
+        } else {
+            reader.discard();
+        }
+    }
+
+    reader.endObject();
+
+    inUse = true;
+}
+
+// Write Vitc to JSON
+void LdDecodeMetaData::Vitc::write(JsonWriter &writer) const
+{
+    assert(inUse);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("vitcData");
+    writer.beginArray();
+    for (auto value : vitcData) {
+        writer.writeElement();
+        writer.write(value);
+    }
+    writer.endArray();
+
+    writer.endObject();
+}
+
+// Read ClosedCaption from JSON
+void LdDecodeMetaData::ClosedCaption::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "data0") reader.read(data0);
+        else if (member == "data1") reader.read(data1);
+        else reader.discard();
+    }
+
+    reader.endObject();
+
+    inUse = true;
+}
+
+// Write ClosedCaption to JSON
+void LdDecodeMetaData::ClosedCaption::write(JsonWriter &writer) const
+{
+    assert(inUse);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    if (data0 != -1) {
+        writer.writeMember("data0", data0);
+    }
+    if (data1 != -1) {
+        writer.writeMember("data1", data1);
+    }
+
+    writer.endObject();
+}
+
+// Read PcmAudioParameters from JSON
+void LdDecodeMetaData::PcmAudioParameters::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "bits") reader.read(bits);
+        else if (member == "isLittleEndian") reader.read(isLittleEndian);
+        else if (member == "isSigned") reader.read(isSigned);
+        else if (member == "sampleRate") reader.read(sampleRate);
+        else reader.discard();
+    }
+
+    reader.endObject();
+
+    isValid = true;
+}
+
+// Write PcmAudioParameters to JSON
+void LdDecodeMetaData::PcmAudioParameters::write(JsonWriter &writer) const
+{
+    assert(isValid);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("bits", bits);
+    writer.writeMember("isLittleEndian", isLittleEndian);
+    writer.writeMember("isSigned", isSigned);
+    writer.writeMember("sampleRate", sampleRate);
+
+    writer.endObject();
+}
+
+// Read Field from JSON
+void LdDecodeMetaData::Field::read(JsonReader &reader)
+{
+    reader.beginObject();
+
+    std::string member;
+    while (reader.readMember(member)) {
+        if (member == "audioSamples") reader.read(audioSamples);
+        else if (member == "cc") closedCaption.read(reader);
+        else if (member == "decodeFaults") reader.read(decodeFaults);
+        else if (member == "diskLoc") reader.read(diskLoc);
+        else if (member == "dropOuts") dropOuts.read(reader);
+        else if (member == "efmTValues") reader.read(efmTValues);
+        else if (member == "fieldPhaseID") reader.read(fieldPhaseID);
+        else if (member == "fileLoc") reader.read(fileLoc);
+        else if (member == "isFirstField") reader.read(isFirstField);
+        else if (member == "medianBurstIRE") reader.read(medianBurstIRE);
+        else if (member == "ntsc") ntsc.read(reader, closedCaption);
+        else if (member == "pad") reader.read(pad);
+        else if (member == "seqNo") reader.read(seqNo);
+        else if (member == "syncConf") reader.read(syncConf);
+        else if (member == "vbi") vbi.read(reader);
+        else if (member == "vitc") vitc.read(reader);
+        else if (member == "vitsMetrics") vitsMetrics.read(reader);
+        else reader.discard();
+    }
+
+    reader.endObject();
+}
+
+// Write Field to JSON
+void LdDecodeMetaData::Field::write(JsonWriter &writer) const
+{
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    if (audioSamples != -1) {
+        writer.writeMember("audioSamples", audioSamples);
+    }
+    if (closedCaption.inUse) {
+        writer.writeMember("cc");
+        closedCaption.write(writer);
+    }
+    if (decodeFaults != -1) {
+        writer.writeMember("decodeFaults", decodeFaults);
+    }
+    if (diskLoc != -1) {
+        writer.writeMember("diskLoc", diskLoc);
+    }
+    if (!dropOuts.empty()) {
+        writer.writeMember("dropOuts");
+        dropOuts.write(writer);
+    }
+    if (efmTValues != -1) {
+        writer.writeMember("efmTValues", efmTValues);
+    }
+    if (fieldPhaseID != -1) {
+        writer.writeMember("fieldPhaseID", fieldPhaseID);
+    }
+    if (fileLoc != -1) {
+        writer.writeMember("fileLoc", fileLoc);
+    }
+    writer.writeMember("isFirstField", isFirstField);
+    writer.writeMember("medianBurstIRE", medianBurstIRE);
+    if (ntsc.inUse) {
+        writer.writeMember("ntsc");
+        ntsc.write(writer);
+    }
+    writer.writeMember("pad", pad);
+    writer.writeMember("seqNo", seqNo);
+    writer.writeMember("syncConf", syncConf);
+    if (vbi.inUse) {
+        writer.writeMember("vbi");
+        vbi.write(writer);
+    }
+    if (vitc.inUse) {
+        writer.writeMember("vitc");
+        vitc.write(writer);
+    }
+    if (vitsMetrics.inUse) {
+        writer.writeMember("vitsMetrics");
+        vitsMetrics.write(writer);
+    }
+
+    writer.endObject();
+}
+
+LdDecodeMetaData::LdDecodeMetaData()
+{
+    clear();
+}
+
+// Reset the metadata to the defaults
+void LdDecodeMetaData::clear()
+{
+    // Default to the standard still-frame field order (of first field first)
+    isFirstFieldFirst = true;
+
+    // Reset the parameters to their defaults
+    videoParameters = VideoParameters();
+    pcmAudioParameters = PcmAudioParameters();
+
+    fields.clear();
+}
+
+// Read all metadata from a JSON file
+bool LdDecodeMetaData::read(std::string fileName)
+{
+    std::ifstream jsonFile(fileName);
+    if (jsonFile.fail()) {
+        spdlog::error("Opening JSON input file failed: JSON file cannot be opened/does not exist");
+        return false;
+    }
+
+    clear();
+
+    JsonReader reader(jsonFile);
+
+    try {
+        reader.beginObject();
+
+        std::string member;
+        while (reader.readMember(member)) {
+            if (member == "fields") readFields(reader);
+            else if (member == "pcmAudioParameters") pcmAudioParameters.read(reader);
+            else if (member == "videoParameters") videoParameters.read(reader);
+            else reader.discard();
+        }
+
+        reader.endObject();
+    } catch (JsonReader::Error &error) {
+        spdlog::error("Parsing JSON file failed: {}", error.what());
+        return false;
+    }
+
+    jsonFile.close();
+
+    // Check we saw VideoParameters - if not, we can't do anything useful!
+    if (!videoParameters.isValid) {
+        spdlog::error("JSON file invalid: videoParameters object is not defined");
+        return false;
+    }
+
+    // Check numberOfSequentialFields is consistent
+    if (videoParameters.numberOfSequentialFields != static_cast<int32_t>(fields.size())) {
+        spdlog::error("JSON file invalid: numberOfSequentialFields does not match fields array");
+        return false;
+    }
+
+    // Now we know the video system, initialise the rest of VideoParameters
+    initialiseVideoSystemParameters();
+
+    // Generate the PCM audio map based on the field metadata
+    generatePcmAudioMap();
+
+    return true;
+}
+
+// Write all metadata out to a JSON file
+bool LdDecodeMetaData::write(std::string fileName) const
+{
+    std::ofstream jsonFile(fileName);
+    if (jsonFile.fail()) {
+        spdlog::error("Opening JSON output file failed");
+        return false;
+    }
+
+    JsonWriter writer(jsonFile);
+
+    writer.beginObject();
+
+    // Keep members in alphabetical order
+    writer.writeMember("fields");
+    writeFields(writer);
+    if (pcmAudioParameters.isValid) {
+        writer.writeMember("pcmAudioParameters");
+        pcmAudioParameters.write(writer);
+    }
+    writer.writeMember("videoParameters");
+    videoParameters.write(writer);
+
+    writer.endObject();
+
+    jsonFile.close();
+
+    return true;
+}
+
+// Read array of Fields from JSON
+void LdDecodeMetaData::readFields(JsonReader &reader)
+{
+    reader.beginArray();
+
+    while (reader.readElement()) {
+        Field field;
+        field.read(reader);
+        fields.push_back(field);
+    }
+
+    reader.endArray();
+}
+
+// Write array of Fields to JSON
+void LdDecodeMetaData::writeFields(JsonWriter &writer) const
+{
+    writer.beginArray();
+
+    for (const Field &field : fields) {
+        writer.writeElement();
+        field.write(writer);
+    }
+
+    writer.endArray();
+}
+
+// This method returns the videoParameters metadata
+const LdDecodeMetaData::VideoParameters &LdDecodeMetaData::getVideoParameters()
+{
+    assert(videoParameters.isValid);
+    return videoParameters;
+}
+
+// This method sets the videoParameters metadata
+void LdDecodeMetaData::setVideoParameters(const LdDecodeMetaData::VideoParameters &_videoParameters)
+{
+    videoParameters = _videoParameters;
+    videoParameters.isValid = true;
+}
+
+// This method returns the pcmAudioParameters metadata
+const LdDecodeMetaData::PcmAudioParameters &LdDecodeMetaData::getPcmAudioParameters()
+{
+    assert(pcmAudioParameters.isValid);
+    return pcmAudioParameters;
+}
+
+// This method sets the pcmAudioParameters metadata
+void LdDecodeMetaData::setPcmAudioParameters(const LdDecodeMetaData::PcmAudioParameters &_pcmAudioParameters)
+{
+    pcmAudioParameters = _pcmAudioParameters;
+    pcmAudioParameters.isValid = true;
+}
+
+// Based on the video system selected, set default values for the members of
+// VideoParameters that aren't obtained from the JSON.
+void LdDecodeMetaData::initialiseVideoSystemParameters()
+{
+    const VideoSystemDefaults &defaults = getSystemDefaults(videoParameters);
+    videoParameters.fSC = defaults.fSC;
+
+    // Set default LineParameters
+    LdDecodeMetaData::LineParameters lineParameters;
+    processLineParameters(lineParameters);
+}
+
+// Validate LineParameters and apply them to the VideoParameters
+void LdDecodeMetaData::processLineParameters(LdDecodeMetaData::LineParameters &lineParameters)
+{
+    lineParameters.applyTo(videoParameters);
+}
+
+// Validate and apply to a set of VideoParameters
+void LdDecodeMetaData::LineParameters::applyTo(LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    const bool firstFieldLineExists = firstActiveFieldLine != -1;
+    const bool lastFieldLineExists = lastActiveFieldLine != -1;
+    const bool firstFrameLineExists = firstActiveFrameLine != -1;
+    const bool lastFrameLineExists = lastActiveFrameLine != -1;
+
+    const VideoSystemDefaults &defaults = getSystemDefaults(videoParameters);
+    const int32_t minFirstFrameLine = defaults.minActiveFrameLine;
+    const int32_t defaultFirstFieldLine = defaults.firstActiveFieldLine;
+    const int32_t defaultLastFieldLine = defaults.lastActiveFieldLine;
+    const int32_t defaultFirstFrameLine = defaults.firstActiveFrameLine;
+    const int32_t defaultLastFrameLine = defaults.lastActiveFrameLine;
+
+    // Validate and potentially fix the first active field line.
+    if (firstActiveFieldLine < 1 || firstActiveFieldLine > defaultLastFieldLine) {
+        if (firstFieldLineExists) {
+            spdlog::info("Specified first active field line {} out of bounds (1 to {}), resetting to default ({}).",
+                         firstActiveFieldLine, defaultLastFieldLine, defaultFirstFieldLine);
+        }
+        firstActiveFieldLine = defaultFirstFieldLine;
+    }
+
+    // Validate and potentially fix the last active field line.
+    if (lastActiveFieldLine < 1 || lastActiveFieldLine > defaultLastFieldLine) {
+        if (lastFieldLineExists) {
+            spdlog::info("Specified last active field line {} out of bounds (1 to {}), resetting to default ({}).",
+                         lastActiveFieldLine, defaultLastFieldLine, defaultLastFieldLine);
+        }
+        lastActiveFieldLine = defaultLastFieldLine;
+    }
+
+    // Range-check the first and last active field lines.
+    if (firstActiveFieldLine > lastActiveFieldLine) {
+        spdlog::info("Specified last active field line {} is before specified first active field line {}, resetting to defaults ({}-{}).",
+                     lastActiveFieldLine, firstActiveFieldLine, defaultFirstFieldLine, defaultLastFieldLine);
+        firstActiveFieldLine = defaultFirstFieldLine;
+        lastActiveFieldLine = defaultLastFieldLine;
+    }
+
+    // Validate and potentially fix the first active frame line.
+    if (firstActiveFrameLine < minFirstFrameLine || firstActiveFrameLine > defaultLastFrameLine) {
+        if (firstFrameLineExists) {
+            spdlog::info("Specified first active frame line {} out of bounds ({} to {}), resetting to default ({}).",
+                         firstActiveFrameLine, minFirstFrameLine, defaultLastFrameLine, defaultFirstFrameLine);
+        }
+        firstActiveFrameLine = defaultFirstFrameLine;
+    }
+
+    // Validate and potentially fix the last active frame line.
+    if (lastActiveFrameLine < minFirstFrameLine || lastActiveFrameLine > defaultLastFrameLine) {
+        if (lastFrameLineExists) {
+            spdlog::info("Specified last active frame line {} out of bounds ({} to {}), resetting to default ({}).",
+                         lastActiveFrameLine, minFirstFrameLine, defaultLastFrameLine, defaultLastFrameLine);
+        }
+        lastActiveFrameLine = defaultLastFrameLine;
+    }
+
+    // Range-check the first and last active frame lines.
+    if (firstActiveFrameLine > lastActiveFrameLine) {
+        spdlog::info("Specified last active frame line {} is before specified first active frame line {}, resetting to defaults ({}-{}).",
+                     lastActiveFrameLine, firstActiveFrameLine, defaultFirstFrameLine, defaultLastFrameLine);
+        firstActiveFrameLine = defaultFirstFrameLine;
+        lastActiveFrameLine = defaultLastFrameLine;
+    }
+
+    // Store the new values back into videoParameters
+    videoParameters.firstActiveFieldLine = firstActiveFieldLine;
+    videoParameters.lastActiveFieldLine = lastActiveFieldLine;
+    videoParameters.firstActiveFrameLine = firstActiveFrameLine;
+    videoParameters.lastActiveFrameLine = lastActiveFrameLine;
+}
+
+// This method gets the metadata for the specified sequential field number (indexed from 1 (not 0!))
+const LdDecodeMetaData::Field &LdDecodeMetaData::getField(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getField(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)];
+}
+
+// This method gets the VITS metrics metadata for the specified sequential field number
+const LdDecodeMetaData::VitsMetrics &LdDecodeMetaData::getFieldVitsMetrics(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldVitsMetrics(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].vitsMetrics;
+}
+
+// This method gets the VBI metadata for the specified sequential field number
+const LdDecodeMetaData::Vbi &LdDecodeMetaData::getFieldVbi(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldVbi(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].vbi;
+}
+
+// This method gets the NTSC metadata for the specified sequential field number
+const LdDecodeMetaData::Ntsc &LdDecodeMetaData::getFieldNtsc(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldNtsc(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].ntsc;
+}
+
+// This method gets the VITC metadata for the specified sequential field number
+const LdDecodeMetaData::Vitc &LdDecodeMetaData::getFieldVitc(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldVitc(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].vitc;
+}
+
+// This method gets the Closed Caption metadata for the specified sequential field number
+const LdDecodeMetaData::ClosedCaption &LdDecodeMetaData::getFieldClosedCaption(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldClosedCaption(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].closedCaption;
+}
+
+// This method gets the drop-out metadata for the specified sequential field number
+const DropOuts &LdDecodeMetaData::getFieldDropOuts(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldDropOuts(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    return fields[static_cast<size_t>(fieldNumber)].dropOuts;
+}
+
+// This method sets the field metadata for a field
+void LdDecodeMetaData::updateField(const LdDecodeMetaData::Field &field, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldVitsMetrics(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)] = field;
+}
+
+// This method sets the field VBI metadata for a field
+void LdDecodeMetaData::updateFieldVitsMetrics(const LdDecodeMetaData::VitsMetrics &vitsMetrics, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldVitsMetrics(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].vitsMetrics = vitsMetrics;
+}
+
+// This method sets the field VBI metadata for a field
+void LdDecodeMetaData::updateFieldVbi(const LdDecodeMetaData::Vbi &vbi, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldVbi(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].vbi = vbi;
+}
+
+// This method sets the field NTSC metadata for a field
+void LdDecodeMetaData::updateFieldNtsc(const LdDecodeMetaData::Ntsc &ntsc, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldNtsc(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[fieldNumber].ntsc = ntsc;
+}
+
+// This method sets the VITC metadata for a field
+void LdDecodeMetaData::updateFieldVitc(const LdDecodeMetaData::Vitc &vitc, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldVitc(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].vitc = vitc;
+}
+
+// This method sets the Closed Caption metadata for a field
+void LdDecodeMetaData::updateFieldClosedCaption(const LdDecodeMetaData::ClosedCaption &closedCaption, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldClosedCaption(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].closedCaption = closedCaption;
+}
+
+// This method sets the field dropout metadata for a field
+void LdDecodeMetaData::updateFieldDropOuts(const DropOuts &dropOuts, int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::updateFieldDropOuts(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].dropOuts = dropOuts;
+}
+
+// This method clears the field dropout metadata for a field
+void LdDecodeMetaData::clearFieldDropOuts(int32_t sequentialFieldNumber)
+{
+    int32_t fieldNumber = sequentialFieldNumber - 1;
+    if (fieldNumber < 0 || fieldNumber >= getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::clearFieldDropOuts(): Requested field number {} out of bounds!", sequentialFieldNumber);
+    }
+
+    fields[static_cast<size_t>(fieldNumber)].dropOuts.clear();
+}
+
+// This method appends a new field to the existing metadata
+void LdDecodeMetaData::appendField(const LdDecodeMetaData::Field &field)
+{
+    // Ensure appended fields receive contiguous sequential numbering
+    LdDecodeMetaData::Field fieldCopy = field;
+    fieldCopy.seqNo = static_cast<int32_t>(fields.size()) + 1;
+    fields.push_back(fieldCopy);
+
+    videoParameters.numberOfSequentialFields = static_cast<int32_t>(fields.size());
+}
+
+// Method to get the available number of fields (according to the metadata)
+int32_t LdDecodeMetaData::getNumberOfFields()
+{
+    return static_cast<int32_t>(fields.size());
+}
+
+// Method to set the available number of fields
+void LdDecodeMetaData::setNumberOfFields(int32_t numberOfFields)
+{
+    videoParameters.numberOfSequentialFields = numberOfFields;
+}
+
+// Method to get the available number of still-frames
+int32_t LdDecodeMetaData::getNumberOfFrames()
+{
+    int32_t frameOffset = 0;
+
+    // If the first field in the TBC input isn't the expected first field,
+    // skip it when counting the number of still-frames
+    if (isFirstFieldFirst) {
+        if (!getField(1).isFirstField) frameOffset = 1;
+    } else {
+        if (getField(1).isFirstField) frameOffset = 1;
+    }
+
+    return (getNumberOfFields() / 2) - frameOffset;
+}
+
+// Method to get the first and second field numbers based on the frame number
+// If field = 1 return the firstField, otherwise return second field
+int32_t LdDecodeMetaData::getFieldNumber(int32_t frameNumber, int32_t field)
+{
+    int32_t firstFieldNumber = 0;
+    int32_t secondFieldNumber = 0;
+
+    // Verify the frame number
+    if (frameNumber < 1) {
+        spdlog::error("Invalid frame number, cannot determine fields");
+        return -1;
+    }
+
+    // Calculate the first and last fields based on the position in the TBC
+    if (isFirstFieldFirst) {
+        firstFieldNumber = (frameNumber * 2) - 1;
+        secondFieldNumber = firstFieldNumber + 1;
+    } else {
+        secondFieldNumber = (frameNumber * 2) - 1;
+        firstFieldNumber = secondFieldNumber + 1;
+    }
+
+    while (!getField(firstFieldNumber).isFirstField) {
+        firstFieldNumber++;
+        secondFieldNumber++;
+
+        if (firstFieldNumber > getNumberOfFields() || secondFieldNumber > getNumberOfFields()) {
+            spdlog::error("Attempting to get field number failed - no isFirstField in JSON before end of file");
+            firstFieldNumber = -1;
+            secondFieldNumber = -1;
+            break;
+        }
+    }
+
+    if (firstFieldNumber > getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldNumber(): First field number exceed the available number of fields!");
+        firstFieldNumber = -1;
+        secondFieldNumber = -1;
+    }
+
+    if (secondFieldNumber > getNumberOfFields()) {
+        spdlog::error("LdDecodeMetaData::getFieldNumber(): Second field number exceed the available number of fields!");
+        firstFieldNumber = -1;
+        secondFieldNumber = -1;
+    }
+
+    if (secondFieldNumber >= 1 && getField(secondFieldNumber).isFirstField) {
+        spdlog::error("LdDecodeMetaData::getFieldNumber(): Both of the determined fields have isFirstField set - the TBC source video is probably broken...");
+    }
+
+    if (field == 1) return firstFieldNumber; else return secondFieldNumber;
+}
+
+// Method to get the first field number based on the frame number
+int32_t LdDecodeMetaData::getFirstFieldNumber(int32_t frameNumber)
+{
+    return getFieldNumber(frameNumber, 1);
+}
+
+// Method to get the second field number based on the frame number
+int32_t LdDecodeMetaData::getSecondFieldNumber(int32_t frameNumber)
+{
+    return getFieldNumber(frameNumber, 2);
+}
+
+// Method to set the isFirstFieldFirst flag
+void LdDecodeMetaData::setIsFirstFieldFirst(bool flag)
+{
+    isFirstFieldFirst = flag;
+}
+
+// Method to get the isFirstFieldFirst flag
+bool LdDecodeMetaData::getIsFirstFieldFirst()
+{
+    return isFirstFieldFirst;
+}
+
+// Method to convert a CLV time code into an equivalent frame number
+int32_t LdDecodeMetaData::convertClvTimecodeToFrameNumber(LdDecodeMetaData::ClvTimecode clvTimeCode)
+{
+    int32_t frameNumber = 0;
+    VideoParameters vp = getVideoParameters();
+
+    if (clvTimeCode.hours == -1 || clvTimeCode.minutes == -1 || clvTimeCode.seconds == -1 || clvTimeCode.pictureNumber == -1) {
+        return -1;
+    }
+
+    if (clvTimeCode.hours != -1) {
+        if (vp.system == LdVideoSystem::PAL) frameNumber += clvTimeCode.hours * 3600 * 25;
+        else frameNumber += clvTimeCode.hours * 3600 * 30;
+    }
+
+    if (clvTimeCode.minutes != -1) {
+        if (vp.system == LdVideoSystem::PAL) frameNumber += clvTimeCode.minutes * 60 * 25;
+        else frameNumber += clvTimeCode.minutes * 60 * 30;
+    }
+
+    if (clvTimeCode.seconds != -1) {
+        if (vp.system == LdVideoSystem::PAL) frameNumber += clvTimeCode.seconds * 25;
+        else frameNumber += clvTimeCode.seconds * 30;
+    }
+
+    if (clvTimeCode.pictureNumber != -1) {
+        frameNumber += clvTimeCode.pictureNumber;
+    }
+
+    return frameNumber;
+}
+
+// Method to convert a frame number into an equivalent CLV timecode
+LdDecodeMetaData::ClvTimecode LdDecodeMetaData::convertFrameNumberToClvTimecode(int32_t frameNumber)
+{
+    ClvTimecode clvTimecode;
+
+    clvTimecode.hours = 0;
+    clvTimecode.minutes = 0;
+    clvTimecode.seconds = 0;
+    clvTimecode.pictureNumber = 0;
+
+    if (getVideoParameters().system == LdVideoSystem::PAL) {
+        clvTimecode.hours = frameNumber / (3600 * 25);
+        frameNumber -= clvTimecode.hours * (3600 * 25);
+
+        clvTimecode.minutes = frameNumber / (60 * 25);
+        frameNumber -= clvTimecode.minutes * (60 * 25);
+
+        clvTimecode.seconds = frameNumber / 25;
+        frameNumber -= clvTimecode.seconds * 25;
+
+        clvTimecode.pictureNumber = frameNumber;
+    } else {
+        clvTimecode.hours = frameNumber / (3600 * 30);
+        frameNumber -= clvTimecode.hours * (3600 * 30);
+
+        clvTimecode.minutes = frameNumber / (60 * 30);
+        frameNumber -= clvTimecode.minutes * (60 * 30);
+
+        clvTimecode.seconds = frameNumber / 30;
+        frameNumber -= clvTimecode.seconds * 30;
+
+        clvTimecode.pictureNumber = frameNumber;
+    }
+
+    return clvTimecode;
+}
+
+// Method to return a description string for the current video format
+std::string LdDecodeMetaData::getVideoSystemDescription() const
+{
+    return getSystemDefaults(videoParameters).name;
+}
+
+// Private method to generate a map of the PCM audio data
+void LdDecodeMetaData::generatePcmAudioMap()
+{
+    pcmAudioFieldStartSampleMap.clear();
+    pcmAudioFieldLengthMap.clear();
+
+    spdlog::debug("LdDecodeMetaData::generatePcmAudioMap(): Generating PCM audio map...");
+
+    int32_t numberOfFields = getVideoParameters().numberOfSequentialFields;
+    pcmAudioFieldStartSampleMap.resize(static_cast<size_t>(numberOfFields + 1));
+    pcmAudioFieldLengthMap.resize(static_cast<size_t>(numberOfFields + 1));
+
+    for (int32_t fieldNo = 0; fieldNo < numberOfFields; fieldNo++) {
+        pcmAudioFieldLengthMap[static_cast<size_t>(fieldNo)] = getField(fieldNo + 1).audioSamples;
+
+        if (fieldNo == 0) {
+            pcmAudioFieldStartSampleMap[0] = 0;
+        } else {
+            pcmAudioFieldStartSampleMap[static_cast<size_t>(fieldNo)] =
+                pcmAudioFieldStartSampleMap[static_cast<size_t>(fieldNo - 1)] +
+                pcmAudioFieldLengthMap[static_cast<size_t>(fieldNo - 1)];
+        }
+    }
+}
+
+// Method to get the start sample location of the specified sequential field number
+int32_t LdDecodeMetaData::getFieldPcmAudioStart(int32_t sequentialFieldNumber)
+{
+    if (static_cast<int32_t>(pcmAudioFieldStartSampleMap.size()) < sequentialFieldNumber) return -1;
+    return pcmAudioFieldStartSampleMap[static_cast<size_t>(sequentialFieldNumber - 1)];
+}
+
+// Method to get the sample length of the specified sequential field number
+int32_t LdDecodeMetaData::getFieldPcmAudioLength(int32_t sequentialFieldNumber)
+{
+    if (static_cast<int32_t>(pcmAudioFieldLengthMap.size()) < sequentialFieldNumber) return -1;
+    return pcmAudioFieldLengthMap[static_cast<size_t>(sequentialFieldNumber - 1)];
+}
+

--- a/orc/core/metadata/lddecodemetadata.h
+++ b/orc/core/metadata/lddecodemetadata.h
@@ -1,0 +1,290 @@
+/************************************************************************
+
+    lddecodemetadata.h
+
+    ld-decode-tools TBC library
+    Copyright (C) 2018-2020 Simon Inns
+    Copyright (C) 2022 Ryan Holtz
+    Copyright (C) 2022-2023 Adam Sampson
+
+    This file is part of ld-decode-tools.
+
+    ld-decode-tools is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+************************************************************************/
+
+// Note: Copied from the TBC library so the JSON handling code is local to the application
+
+#ifndef LDDECODEMETADATA_H
+#define LDDECODEMETADATA_H
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <array>
+
+#include "dropouts.h"
+
+class JsonReader;
+class JsonWriter;
+
+// The video system (combination of a line standard and a colour standard)
+// Note: If you update this, be sure to update VIDEO_SYSTEM_DEFAULTS also
+// Renamed to LdVideoSystem to avoid collision with orc::VideoSystem
+enum class LdVideoSystem {
+    PAL = 0,    // 625-line PAL
+    NTSC,       // 525-line NTSC
+    PAL_M,      // 525-line PAL
+};
+
+bool parseVideoSystemName(std::string name, LdVideoSystem &system);
+
+class LdDecodeMetaData
+{
+
+public:
+    // VBI Metadata definition
+    struct Vbi {
+        bool inUse = false;
+        std::array<int32_t, 3> vbiData { 0, 0, 0 };
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // Video metadata definition
+    struct VideoParameters {
+        // -- Members stored in the JSON metadata --
+
+        int32_t numberOfSequentialFields = -1;
+
+        LdVideoSystem system = LdVideoSystem::NTSC;
+        bool isSubcarrierLocked = false;
+        bool isWidescreen = false;
+
+        int32_t colourBurstStart = -1;
+        int32_t colourBurstEnd = -1;
+        int32_t activeVideoStart = -1;
+        int32_t activeVideoEnd = -1;
+
+        int32_t white16bIre = -1;
+        int32_t black16bIre = -1;
+
+        int32_t fieldWidth = -1;
+        int32_t fieldHeight = -1;
+        double sampleRate = -1.0;
+
+        bool isMapped = false;
+        std::string tapeFormat = "";
+
+        std::string gitBranch;
+        std::string gitCommit;
+
+        // -- Members set by the library --
+
+        // Colour subcarrier frequency in Hz
+        double fSC = -1.0;
+
+        // The range of active lines within a frame.
+        int32_t firstActiveFieldLine = -1;
+        int32_t lastActiveFieldLine = -1;
+        int32_t firstActiveFrameLine = -1;
+        int32_t lastActiveFrameLine = -1;
+
+        // Flags if our data has been initialized yet
+        bool isValid = false;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // Specification for customising the range of active lines in VideoParameters.
+    struct LineParameters {
+        int32_t firstActiveFieldLine = -1;
+        int32_t lastActiveFieldLine = -1;
+        int32_t firstActiveFrameLine = -1;
+        int32_t lastActiveFrameLine = -1;
+
+        void applyTo(VideoParameters &videoParameters);
+    };
+
+    // VITS metrics metadata definition
+    struct VitsMetrics {
+        bool inUse = false;
+        double wSNR = 0.0;
+        double bPSNR = 0.0;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // NTSC Specific metadata definition
+    struct ClosedCaption;
+    struct Ntsc {
+        bool inUse = false;
+        bool isFmCodeDataValid = false;
+        int32_t fmCodeData = 0;
+        bool fieldFlag = false;
+        bool isVideoIdDataValid = false;
+        int32_t videoIdData = 0;
+        bool whiteFlag = false;
+
+        void read(JsonReader &reader, ClosedCaption &closedCaption);
+        void write(JsonWriter &writer) const;
+    };
+
+    // VITC timecode definition
+    struct Vitc {
+        bool inUse = false;
+
+        std::array<int32_t, 8> vitcData;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // Closed Caption definition
+    struct ClosedCaption {
+        bool inUse = false;
+
+        int32_t data0 = -1;
+        int32_t data1 = -1;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // PCM sound metadata definition
+    struct PcmAudioParameters {
+        double sampleRate = -1.0;
+        bool isLittleEndian = false;
+        bool isSigned = false;
+        int32_t bits = -1;
+
+        // Flags if our data has been initialized yet
+        bool isValid = false;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // Field metadata definition
+    struct Field {
+        int32_t seqNo = 0;   // Note: This is the unique primary-key
+        bool isFirstField = false;
+        int32_t syncConf = 0;
+        double medianBurstIRE = 0.0;
+        int32_t fieldPhaseID = -1;
+        int32_t audioSamples = -1;
+
+        VitsMetrics vitsMetrics;
+        Vbi vbi;
+        Ntsc ntsc;
+        Vitc vitc;
+        ClosedCaption closedCaption;
+        DropOuts dropOuts;
+        bool pad = false;
+
+        double diskLoc = -1;
+        int64_t fileLoc = -1;
+        int32_t decodeFaults = -1;
+        int32_t efmTValues = -1;
+
+        void read(JsonReader &reader);
+        void write(JsonWriter &writer) const;
+    };
+
+    // CLV timecode (used by frame number conversion methods)
+    struct ClvTimecode {
+        int32_t hours;
+        int32_t minutes;
+        int32_t seconds;
+        int32_t pictureNumber;
+    };
+
+    LdDecodeMetaData();
+
+    // Prevent copying or assignment
+    LdDecodeMetaData(const LdDecodeMetaData &) = delete;
+    LdDecodeMetaData& operator=(const LdDecodeMetaData &) = delete;
+
+    void clear();
+    bool read(std::string fileName);
+    bool write(std::string fileName) const;
+    void readFields(JsonReader &reader);
+    void writeFields(JsonWriter &writer) const;
+
+    const VideoParameters &getVideoParameters();
+    void setVideoParameters(const VideoParameters &videoParameters);
+
+    const PcmAudioParameters &getPcmAudioParameters();
+    void setPcmAudioParameters(const PcmAudioParameters &pcmAudioParam);
+
+    // Handle line parameters
+    void processLineParameters(LdDecodeMetaData::LineParameters &_lineParameters);
+
+    // Get field metadata
+    const Field &getField(int32_t sequentialFieldNumber);
+    const VitsMetrics &getFieldVitsMetrics(int32_t sequentialFieldNumber);
+    const Vbi &getFieldVbi(int32_t sequentialFieldNumber);
+    const Ntsc &getFieldNtsc(int32_t sequentialFieldNumber);
+    const Vitc &getFieldVitc(int32_t sequentialFieldNumber);
+    const ClosedCaption &getFieldClosedCaption(int32_t sequentialFieldNumber);
+    const DropOuts &getFieldDropOuts(int32_t sequentialFieldNumber);
+
+    // Set field metadata
+    void updateField(const Field &field, int32_t sequentialFieldNumber);
+    void updateFieldVitsMetrics(const LdDecodeMetaData::VitsMetrics &vitsMetrics, int32_t sequentialFieldNumber);
+    void updateFieldVbi(const LdDecodeMetaData::Vbi &vbi, int32_t sequentialFieldNumber);
+    void updateFieldNtsc(const LdDecodeMetaData::Ntsc &ntsc, int32_t sequentialFieldNumber);
+    void updateFieldVitc(const LdDecodeMetaData::Vitc &vitc, int32_t sequentialFieldNumber);
+    void updateFieldClosedCaption(const LdDecodeMetaData::ClosedCaption &closedCaption, int32_t sequentialFieldNumber);
+    void updateFieldDropOuts(const DropOuts &dropOuts, int32_t sequentialFieldNumber);
+    void clearFieldDropOuts(int32_t sequentialFieldNumber);
+
+    void appendField(const Field &field);
+
+    void setNumberOfFields(int32_t numberOfFields);
+    int32_t getNumberOfFields();
+    int32_t getNumberOfFrames();
+    int32_t getFirstFieldNumber(int32_t frameNumber);
+    int32_t getSecondFieldNumber(int32_t frameNumber);
+
+    void setIsFirstFieldFirst(bool flag);
+    bool getIsFirstFieldFirst();
+
+    int32_t convertClvTimecodeToFrameNumber(LdDecodeMetaData::ClvTimecode clvTimeCode);
+    LdDecodeMetaData::ClvTimecode convertFrameNumberToClvTimecode(int32_t clvFrameNumber);
+
+    // PCM Analogue audio helper methods
+    int32_t getFieldPcmAudioStart(int32_t sequentialFieldNumber);
+    int32_t getFieldPcmAudioLength(int32_t sequentialFieldNumber);
+
+    // Video system helper methods
+    std::string getVideoSystemDescription() const;
+
+private:
+    bool isFirstFieldFirst;
+    VideoParameters videoParameters;
+    PcmAudioParameters pcmAudioParameters;
+    std::vector<Field> fields;
+    std::vector<int32_t> pcmAudioFieldStartSampleMap;
+    std::vector<int32_t> pcmAudioFieldLengthMap;
+
+    void initialiseVideoSystemParameters();
+    int32_t getFieldNumber(int32_t frameNumber, int32_t field);
+    void generatePcmAudioMap();
+};
+
+#endif // LDDECODEMETADATA_H

--- a/orc/core/metadata/logging.h
+++ b/orc/core/metadata/logging.h
@@ -1,0 +1,21 @@
+/*
+ * File:        logging.h
+ * Module:      orc-metadata
+ * Purpose:     Logging wrapper for orc-metadata (spdlog default logger, no orc-core dependency)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+// Convenience macros matching the ORC_LOG_* API used throughout the codebase.
+// These forward to spdlog's default logger so that orc-metadata has no link-time
+// dependency on orc-core's orc::get_logger() function.
+#define ORC_LOG_TRACE(...)    SPDLOG_TRACE(__VA_ARGS__)
+#define ORC_LOG_DEBUG(...)    SPDLOG_DEBUG(__VA_ARGS__)
+#define ORC_LOG_INFO(...)     SPDLOG_INFO(__VA_ARGS__)
+#define ORC_LOG_WARN(...)     SPDLOG_WARN(__VA_ARGS__)
+#define ORC_LOG_ERROR(...)    SPDLOG_ERROR(__VA_ARGS__)

--- a/orc/core/metadata/open_tbc_metadata.cpp
+++ b/orc/core/metadata/open_tbc_metadata.cpp
@@ -1,0 +1,50 @@
+/*
+ * File:        open_tbc_metadata.cpp
+ * Module:      orc-metadata
+ * Purpose:     Factory function for opening TBC metadata readers
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025-2026 Simon Inns
+ */
+
+#include <open_tbc_metadata.h>
+#include <tbc_metadata.h>
+#include <tbc_metadata_json_reader.h>
+#include "logging.h"
+#include <filesystem>
+
+namespace orc {
+
+std::unique_ptr<ITBCMetadataReader> open_tbc_metadata(const std::string& db_path)
+{
+    // Primary path: open the SQLite .tbc.db file if it exists.
+    if (std::filesystem::exists(db_path)) {
+        auto reader = std::make_unique<TBCMetadataSqliteReader>();
+        if (!reader->open(db_path)) {
+            ORC_LOG_ERROR("open_tbc_metadata: failed to open SQLite database: {}", db_path);
+            return nullptr;
+        }
+        return reader;
+    }
+
+    // Fallback: look for a legacy .tbc.json alongside the expected .tbc.db path.
+    // The db_path convention is "<stem>.tbc.db"; the JSON path is "<stem>.tbc.json".
+    if (db_path.size() > 3 && db_path.compare(db_path.size() - 3, 3, ".db") == 0) {
+        std::string json_path = db_path.substr(0, db_path.size() - 3) + ".json";
+        if (std::filesystem::exists(json_path)) {
+            ORC_LOG_WARN("open_tbc_metadata: .tbc.db not found; falling back to legacy JSON: {}", json_path);
+            auto reader = std::make_unique<TBCMetadataJsonReader>();
+            if (!reader->open(json_path)) {
+                ORC_LOG_ERROR("open_tbc_metadata: failed to convert JSON metadata: {}", json_path);
+                return nullptr;
+            }
+            return reader;
+        }
+    }
+
+    // Neither file exists.
+    ORC_LOG_ERROR("open_tbc_metadata: metadata file not found: {}", db_path);
+    return nullptr;
+}
+
+} // namespace orc

--- a/orc/core/metadata/tbc_metadata.cpp
+++ b/orc/core/metadata/tbc_metadata.cpp
@@ -1,6 +1,6 @@
 /*
  * File:        tbc_metadata.cpp
- * Module:      orc-core
+ * Module:      orc-metadata
  * Purpose:     Tbc Metadata
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -8,7 +8,7 @@
  */
 
 
-#include "tbc_source_internal/tbc_metadata.h"
+#include <tbc_metadata.h>
 #include "logging.h"
 #include <stdexcept>
 #include <sqlite3.h>
@@ -44,10 +44,10 @@ VideoSystem video_system_from_string(const std::string& name) {
 }
 
 // ============================================================================
-// TBCMetadataReader::Impl (Private implementation using SQLite)
+// TBCMetadataSqliteReader::Impl (Private implementation using SQLite)
 // ============================================================================
 
-class TBCMetadataReader::Impl {
+class TBCMetadataSqliteReader::Impl {
 public:
     sqlite3* db = nullptr;
     int capture_id = 1;  // Default capture ID
@@ -152,18 +152,18 @@ public:
 };
 
 // ============================================================================
-// TBCMetadataReader implementation
+// TBCMetadataSqliteReader implementation
 // ============================================================================
 
-TBCMetadataReader::TBCMetadataReader()
+TBCMetadataSqliteReader::TBCMetadataSqliteReader()
     : impl_(std::make_unique<Impl>()), is_open_(false) {
 }
 
-TBCMetadataReader::~TBCMetadataReader() {
+TBCMetadataSqliteReader::~TBCMetadataSqliteReader() {
     close();
 }
 
-bool TBCMetadataReader::open(const std::string& filename) {
+bool TBCMetadataSqliteReader::open(const std::string& filename) {
     close();
     
     int rc = sqlite3_open_v2(filename.c_str(), &impl_->db, 
@@ -181,7 +181,16 @@ bool TBCMetadataReader::open(const std::string& filename) {
     return true;
 }
 
-void TBCMetadataReader::close() {
+bool TBCMetadataSqliteReader::open_from_handle(sqlite3* db)
+{
+    close();
+    if (!db) return false;
+    impl_->db = db;
+    is_open_ = true;
+    return true;
+}
+
+void TBCMetadataSqliteReader::close() {
     if (impl_->db) {
         sqlite3_close(impl_->db);
         impl_->db = nullptr;
@@ -189,7 +198,7 @@ void TBCMetadataReader::close() {
     is_open_ = false;
 }
 
-std::optional<SourceParameters> TBCMetadataReader::read_video_parameters() {
+std::optional<SourceParameters> TBCMetadataSqliteReader::read_video_parameters() {
     if (!is_open_) {
         ORC_LOG_DEBUG("read_video_parameters: Metadata database is not open");
         return std::nullopt;
@@ -311,7 +320,7 @@ std::optional<SourceParameters> TBCMetadataReader::read_video_parameters() {
     return std::nullopt;
 }
 
-std::optional<PcmAudioParameters> TBCMetadataReader::read_pcm_audio_parameters() {
+std::optional<PcmAudioParameters> TBCMetadataSqliteReader::read_pcm_audio_parameters() {
     if (!is_open_) {
         return std::nullopt;
     }
@@ -345,7 +354,7 @@ std::optional<PcmAudioParameters> TBCMetadataReader::read_pcm_audio_parameters()
     return std::nullopt;
 }
 
-void TBCMetadataReader::preload_cache() {
+void TBCMetadataSqliteReader::preload_cache() {
     if (!is_open_) {
         return;
     }
@@ -361,7 +370,7 @@ void TBCMetadataReader::preload_cache() {
     }
 }
 
-std::optional<FieldMetadata> TBCMetadataReader::read_field_metadata(FieldID field_id) {
+std::optional<FieldMetadata> TBCMetadataSqliteReader::read_field_metadata(FieldID field_id) {
     if (!is_open_ || !field_id.is_valid()) {
         return std::nullopt;
     }
@@ -386,7 +395,7 @@ std::optional<FieldMetadata> TBCMetadataReader::read_field_metadata(FieldID fiel
     return std::nullopt;
 }
 
-std::map<FieldID, FieldMetadata> TBCMetadataReader::read_all_field_metadata() {
+std::map<FieldID, FieldMetadata> TBCMetadataSqliteReader::read_all_field_metadata() {
     std::map<FieldID, FieldMetadata> result;
     
     if (!is_open_) {
@@ -429,7 +438,7 @@ std::map<FieldID, FieldMetadata> TBCMetadataReader::read_all_field_metadata() {
     return result;
 }
 
-std::optional<VbiData> TBCMetadataReader::read_vbi(FieldID field_id) {
+std::optional<VbiData> TBCMetadataSqliteReader::read_vbi(FieldID field_id) {
     if (!is_open_ || !field_id.is_valid()) {
         return std::nullopt;
     }
@@ -499,7 +508,7 @@ std::optional<VbiData> TBCMetadataReader::read_vbi(FieldID field_id) {
     return std::nullopt;
 }
 
-std::optional<VitcData> TBCMetadataReader::read_vitc(FieldID field_id) {
+std::optional<VitcData> TBCMetadataSqliteReader::read_vitc(FieldID field_id) {
     if (!is_open_ || !field_id.is_valid()) {
         return std::nullopt;
     }
@@ -508,7 +517,7 @@ std::optional<VitcData> TBCMetadataReader::read_vitc(FieldID field_id) {
     return std::nullopt;
 }
 
-std::optional<ClosedCaptionData> TBCMetadataReader::read_closed_caption(FieldID field_id) {
+std::optional<ClosedCaptionData> TBCMetadataSqliteReader::read_closed_caption(FieldID field_id) {
     if (!is_open_ || !field_id.is_valid()) {
         return std::nullopt;
     }
@@ -543,7 +552,7 @@ std::optional<ClosedCaptionData> TBCMetadataReader::read_closed_caption(FieldID 
     return std::nullopt;
 }
 
-std::vector<DropoutInfo> TBCMetadataReader::read_dropouts(FieldID field_id) const {
+std::vector<DropoutInfo> TBCMetadataSqliteReader::read_dropouts(FieldID field_id) const {
     if (!is_open_ || !field_id.is_valid()) {
         return {};
     }
@@ -561,7 +570,7 @@ std::vector<DropoutInfo> TBCMetadataReader::read_dropouts(FieldID field_id) cons
     return {};
 }
 
-void TBCMetadataReader::read_all_dropouts() {
+void TBCMetadataSqliteReader::read_all_dropouts() {
     if (!is_open_) {
         return;
     }
@@ -597,7 +606,7 @@ void TBCMetadataReader::read_all_dropouts() {
     sqlite3_finalize(stmt);
 }
 
-std::optional<DropoutData> TBCMetadataReader::read_dropout(FieldID field_id) const {
+std::optional<DropoutData> TBCMetadataSqliteReader::read_dropout(FieldID field_id) const {
     auto dropouts = read_dropouts(field_id);
     if (dropouts.empty()) {
         return std::nullopt;
@@ -608,7 +617,7 @@ std::optional<DropoutData> TBCMetadataReader::read_dropout(FieldID field_id) con
     return data;
 }
 
-int32_t TBCMetadataReader::get_field_record_count() const {
+int32_t TBCMetadataSqliteReader::get_field_record_count() const {
     if (!is_open_) {
         return -1;
     }
@@ -633,7 +642,7 @@ int32_t TBCMetadataReader::get_field_record_count() const {
     return count;
 }
 
-bool TBCMetadataReader::validate_metadata(std::string* error_message) const {
+bool TBCMetadataSqliteReader::validate_metadata(std::string* error_message) const {
     if (!is_open_) {
         if (error_message) {
             *error_message = "Metadata database is not open";

--- a/orc/core/metadata/tbc_metadata_json_reader.cpp
+++ b/orc/core/metadata/tbc_metadata_json_reader.cpp
@@ -1,0 +1,331 @@
+/*
+ * File:        tbc_metadata_json_reader.cpp
+ * Module:      orc-metadata
+ * Purpose:     JSON-backed TBC metadata reader (Phase 4)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include <tbc_metadata_json_reader.h>
+#include "logging.h"
+#include "lddecodemetadata.h"
+
+namespace orc {
+
+TBCMetadataJsonReader::TBCMetadataJsonReader() = default;
+
+TBCMetadataJsonReader::~TBCMetadataJsonReader()
+{
+    close();
+}
+
+bool TBCMetadataJsonReader::open(const std::string& json_path)
+{
+    close();
+
+    LdDecodeMetaData meta;
+    if (!meta.read(json_path)) {
+        ORC_LOG_ERROR("TBCMetadataJsonReader: failed to read JSON metadata from {}", json_path);
+        return false;
+    }
+
+    // ---- Source (video) parameters ----
+    const auto& vp = meta.getVideoParameters();
+    SourceParameters sp;
+
+    switch (vp.system) {
+        case LdVideoSystem::PAL:   sp.system = VideoSystem::PAL;   break;
+        case LdVideoSystem::NTSC:  sp.system = VideoSystem::NTSC;  break;
+        case LdVideoSystem::PAL_M: sp.system = VideoSystem::PAL_M; break;
+    }
+
+    sp.sample_rate                = vp.sampleRate;
+    sp.active_video_start         = vp.activeVideoStart;
+    sp.active_video_end           = vp.activeVideoEnd;
+    sp.field_width                = vp.fieldWidth;
+    sp.field_height               = vp.fieldHeight;
+    sp.number_of_sequential_fields = vp.numberOfSequentialFields;
+    sp.colour_burst_start         = vp.colourBurstStart;
+    sp.colour_burst_end           = vp.colourBurstEnd;
+    sp.is_mapped                  = vp.isMapped;
+    sp.is_subcarrier_locked       = vp.isSubcarrierLocked;
+    sp.is_widescreen              = vp.isWidescreen;
+    sp.white_16b_ire              = vp.white16bIre;
+    sp.black_16b_ire              = vp.black16bIre;
+    sp.blanking_16b_ire           = vp.black16bIre; // legacy JSON: no blanking level, use black
+    sp.git_branch                 = vp.gitBranch;
+    sp.git_commit                 = vp.gitCommit;
+    sp.tape_format                = vp.tapeFormat;
+    sp.decoder                    = "ld-decode";
+    sp.fsc                        = -1.0; // not stored; computed by source stage from video system
+
+    // Active line boundaries — mirrors TBCMetadataSqliteReader::read_video_parameters()
+    if (sp.system == VideoSystem::PAL) {
+        sp.first_active_frame_line = 44;
+        sp.last_active_frame_line  = 620;
+        sp.first_active_field_line = 22;
+        sp.last_active_field_line  = 310;
+    } else { // NTSC and PAL_M
+        sp.first_active_frame_line = 40;
+        sp.last_active_frame_line  = 525;
+        sp.first_active_field_line = 20;
+        sp.last_active_field_line  = 259;
+    }
+
+    source_params_ = sp;
+
+    // ---- PCM audio parameters ----
+    const auto& ap = meta.getPcmAudioParameters();
+    if (ap.sampleRate > 0) {
+        PcmAudioParameters orc_ap;
+        orc_ap.sample_rate      = ap.sampleRate;
+        orc_ap.bits             = ap.bits;
+        orc_ap.is_signed        = ap.isSigned;
+        orc_ap.is_little_endian = ap.isLittleEndian;
+        audio_params_ = orc_ap;
+    }
+
+    // ---- Per-field data ----
+    // Field IDs are 0-based (fieldNum 1 → FieldID 0), matching the SQLite reader.
+    int32_t num_fields = meta.getNumberOfFields();
+    for (int32_t field_num = 1; field_num <= num_fields; ++field_num) {
+        const auto& f  = meta.getField(field_num);
+        FieldID fid(static_cast<FieldID::value_type>(field_num - 1));
+
+        // Core field record — mirrors read_all_field_metadata() SQLite query columns
+        FieldMetadata fm;
+        fm.seq_no          = static_cast<int32_t>(fid.value());
+        fm.is_first_field  = f.isFirstField;
+        fm.sync_confidence = f.syncConf;
+        fm.median_burst_ire = f.medianBurstIRE;
+        fm.field_phase_id  = f.fieldPhaseID;
+        fm.is_pad          = f.pad;
+        if (f.audioSamples > 0) fm.audio_samples = f.audioSamples;
+        if (f.decodeFaults > 0) fm.decode_faults  = f.decodeFaults;
+        if (f.diskLoc > 0.0)    fm.disk_location  = f.diskLoc;
+        if (f.efmTValues > 0)   fm.efm_t_values   = f.efmTValues;
+        if (f.fileLoc > 0)      fm.file_location  = f.fileLoc;
+        field_cache_[fid] = fm;
+
+        // VBI
+        if (f.vbi.inUse) {
+            VbiData orc_vbi;
+            orc_vbi.in_use   = true;
+            orc_vbi.vbi_data = f.vbi.vbiData;
+            vbi_cache_[fid]  = orc_vbi;
+        }
+
+        // VITC
+        if (f.vitc.inUse) {
+            VitcData orc_vitc;
+            orc_vitc.in_use    = true;
+            orc_vitc.vitc_data = f.vitc.vitcData;
+            vitc_cache_[fid]   = orc_vitc;
+        }
+
+        // Closed caption
+        if (f.closedCaption.inUse) {
+            ClosedCaptionData orc_cc;
+            orc_cc.in_use = true;
+            orc_cc.data0  = f.closedCaption.data0;
+            orc_cc.data1  = f.closedCaption.data1;
+            cc_cache_[fid] = orc_cc;
+        }
+
+        // Dropouts (legacy JSON uses 1-based line numbers; convert to 0-based to match SQLite reader)
+        const auto& dos = f.dropOuts;
+        if (dos.size() > 0) {
+            std::vector<DropoutInfo> orc_dos;
+            orc_dos.reserve(static_cast<size_t>(dos.size()));
+            for (int32_t i = 0; i < dos.size(); ++i) {
+                DropoutInfo di;
+                di.line         = static_cast<uint32_t>(dos.fieldLine(i)) - 1;
+                di.start_sample = static_cast<uint32_t>(dos.startx(i));
+                di.end_sample   = static_cast<uint32_t>(dos.endx(i));
+                orc_dos.push_back(di);
+            }
+            dropout_cache_[fid] = std::move(orc_dos);
+        }
+    }
+
+    is_open_ = true;
+    ORC_LOG_INFO("TBCMetadataJsonReader: loaded {} fields from {}", num_fields, json_path);
+    return true;
+}
+
+void TBCMetadataJsonReader::close()
+{
+    is_open_ = false;
+    source_params_.reset();
+    audio_params_.reset();
+    field_cache_.clear();
+    vbi_cache_.clear();
+    vitc_cache_.clear();
+    cc_cache_.clear();
+    dropout_cache_.clear();
+}
+
+bool TBCMetadataJsonReader::is_open() const
+{
+    return is_open_;
+}
+
+std::optional<SourceParameters> TBCMetadataJsonReader::read_video_parameters()
+{
+    return source_params_;
+}
+
+std::optional<PcmAudioParameters> TBCMetadataJsonReader::read_pcm_audio_parameters()
+{
+    return audio_params_;
+}
+
+std::optional<FieldMetadata> TBCMetadataJsonReader::read_field_metadata(FieldID field_id)
+{
+    if (!is_open_ || !field_id.is_valid()) {
+        return std::nullopt;
+    }
+    auto it = field_cache_.find(field_id);
+    if (it != field_cache_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::map<FieldID, FieldMetadata> TBCMetadataJsonReader::read_all_field_metadata()
+{
+    return field_cache_;
+}
+
+void TBCMetadataJsonReader::read_all_dropouts()
+{
+    // All dropouts are already loaded eagerly in open(); nothing to do.
+}
+
+void TBCMetadataJsonReader::preload_cache()
+{
+    // All data is loaded eagerly in open(); nothing to do.
+}
+
+std::optional<VbiData> TBCMetadataJsonReader::read_vbi(FieldID field_id)
+{
+    if (!is_open_ || !field_id.is_valid()) {
+        return std::nullopt;
+    }
+    auto it = vbi_cache_.find(field_id);
+    if (it != vbi_cache_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::optional<VitcData> TBCMetadataJsonReader::read_vitc(FieldID field_id)
+{
+    if (!is_open_ || !field_id.is_valid()) {
+        return std::nullopt;
+    }
+    auto it = vitc_cache_.find(field_id);
+    if (it != vitc_cache_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::optional<ClosedCaptionData> TBCMetadataJsonReader::read_closed_caption(FieldID field_id)
+{
+    if (!is_open_ || !field_id.is_valid()) {
+        return std::nullopt;
+    }
+    auto it = cc_cache_.find(field_id);
+    if (it != cc_cache_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+std::optional<DropoutData> TBCMetadataJsonReader::read_dropout(FieldID field_id) const
+{
+    auto dropouts = read_dropouts(field_id);
+    if (dropouts.empty()) {
+        return std::nullopt;
+    }
+    DropoutData data;
+    data.dropouts = std::move(dropouts);
+    return data;
+}
+
+std::vector<DropoutInfo> TBCMetadataJsonReader::read_dropouts(FieldID field_id) const
+{
+    if (!is_open_ || !field_id.is_valid()) {
+        return {};
+    }
+    auto it = dropout_cache_.find(field_id);
+    if (it != dropout_cache_.end()) {
+        return it->second;
+    }
+    return {};
+}
+
+int32_t TBCMetadataJsonReader::get_field_record_count() const
+{
+    return static_cast<int32_t>(field_cache_.size());
+}
+
+bool TBCMetadataJsonReader::validate_metadata(std::string* error_message) const
+{
+    if (!is_open_) {
+        if (error_message) *error_message = "Metadata is not open";
+        ORC_LOG_ERROR("validate_metadata: {}", error_message ? *error_message : "not open");
+        return false;
+    }
+
+    if (!source_params_) {
+        if (error_message) *error_message = "Failed to read video parameters from metadata";
+        ORC_LOG_ERROR("validate_metadata: {} - check debug logs for details",
+                      error_message ? *error_message : "Unknown error");
+        return false;
+    }
+
+    const auto& params = *source_params_;
+
+    if (params.number_of_sequential_fields <= 0) {
+        if (error_message) {
+            *error_message = "Metadata does not specify valid number_of_sequential_fields (" +
+                             std::to_string(params.number_of_sequential_fields) + ")";
+        }
+        ORC_LOG_ERROR("validate_metadata: {}",
+                      error_message ? *error_message : "invalid number_of_sequential_fields");
+        return false;
+    }
+
+    int32_t field_count = get_field_record_count();
+    if (field_count != params.number_of_sequential_fields) {
+        if (error_message) {
+            *error_message = "Metadata inconsistency: video parameters specifies " +
+                             std::to_string(params.number_of_sequential_fields) +
+                             " fields, but " + std::to_string(field_count) + " field records loaded. "
+                             "This TBC file has inconsistent metadata, likely from a buggy "
+                             "ld-decode version or interrupted capture.";
+        }
+        return false;
+    }
+
+    if (params.field_width <= 0 || params.field_height <= 0) {
+        if (error_message) {
+            *error_message = "Invalid field dimensions: " +
+                             std::to_string(params.field_width) + "x" +
+                             std::to_string(params.field_height);
+        }
+        return false;
+    }
+
+    if (params.system == VideoSystem::Unknown) {
+        if (error_message) *error_message = "Unknown or unsupported video system";
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace orc

--- a/orc/core/metadata/tbc_metadata_writer.cpp
+++ b/orc/core/metadata/tbc_metadata_writer.cpp
@@ -1,19 +1,13 @@
 /*
  * File:        tbc_metadata_writer.cpp
- * Module:      orc-core
+ * Module:      orc-metadata
  * Purpose:     TBC Metadata Writer implementation
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025-2026 Simon Inns
  */
 
-#include "tbc_metadata_writer.h"
-#include "biphase_observer.h"
-#include "closed_caption_observer.h"
-#include "white_snr_observer.h"
-#include "black_psnr_observer.h"
-#include "burst_level_observer.h"
-#include "observation_context.h"
+#include <tbc_metadata_writer.h>
 #include "logging.h"
 #include <sqlite3.h>
 #include <stdexcept>
@@ -587,7 +581,7 @@ bool TBCMetadataWriter::write_dropout(FieldID field_id, const DropoutInfo& dropo
     return rc == SQLITE_DONE;
 }
 
-bool TBCMetadataWriter::write_observations(FieldID field_id, const ObservationContext& context) {
+bool TBCMetadataWriter::write_observations(FieldID field_id, const IObservationContext& context) {
     if (!is_open_ || capture_id_ < 0) return false;
     
     bool any_written = false;

--- a/orc/core/project.cpp
+++ b/orc/core/project.cpp
@@ -29,7 +29,7 @@
  */
 
 #include "project.h"
-#include "tbc_source_internal/tbc_metadata.h"
+#include <tbc_metadata.h>
 #include "logging.h"
 #include "stage_registry.h"
 #include "project_to_dag.h"
@@ -634,76 +634,19 @@ void set_node_parameters(Project& project, NodeID node_id,
             
             // Only validate if a path is provided (empty is allowed)
             if (!input_path.empty()) {
-                // Validate using the existing add_source_to_project validation logic
-                std::string db_path = input_path + ".db";
-                
-                try {
-                    // Load metadata to validate system
-                    auto metadata_reader = std::make_shared<TBCMetadataReader>();
-                    if (!metadata_reader->open(db_path)) {
-                        throw std::runtime_error("Failed to open TBC metadata database: " + db_path);
-                    }
-                    
-                    auto video_params = metadata_reader->read_video_parameters();
-                    if (!video_params) {
-                        throw std::runtime_error("No video parameters found in TBC metadata");
-                    }
-                    
-                    // Validate decoder
-                if (video_params->decoder != "ld-decode" && video_params->decoder != "encode-orc") {
+                // Check that a metadata file exists (either .tbc.db or legacy .tbc.json).
+                // Full decoder/system validation is deferred to the source stage on first
+                // execution, which calls create_tbc_representation() → open_tbc_metadata()
+                // and reports any mismatch with a clear error at that point.
+                // input_path is the .tbc file; metadata lives alongside as .tbc.db or .tbc.json
+                std::string db_path   = input_path + ".db";
+                std::string json_path = input_path + ".json";
+                bool metadata_exists = std::filesystem::exists(db_path) ||
+                                       std::filesystem::exists(json_path);
+                if (!metadata_exists) {
                     throw std::runtime_error(
-                        "TBC file was not created by ld-decode or encode-orc (decoder: " + 
-                        video_params->decoder + "). This source type requires ld-decode or encode-orc files."
-                    );
-                }
-                
-                // Validate system matches the node's stage type
-                    if (node_it->stage_name == "PAL_Comp_Source") {
-                        if (video_params->system != VideoSystem::PAL && 
-                            video_params->system != VideoSystem::PAL_M) {
-                            throw std::runtime_error(
-                                "Selected TBC file is not PAL format. This is a PAL source node - use an NTSC source node for NTSC files."
-                            );
-                        }
-                    } else if (node_it->stage_name == "NTSC_Comp_Source") {
-                        if (video_params->system != VideoSystem::NTSC) {
-                            throw std::runtime_error(
-                                "Selected TBC file is not NTSC format. This is an NTSC source node - use a PAL source node for PAL files."
-                            );
-                        }
-                    }
-                    
-                    // Check consistency with other sources in the project
-                    for (const auto& other_node : project.nodes_) {
-                        if (other_node.node_id != node_id && other_node.node_type == NodeType::SOURCE) {
-                            if (other_node.stage_name != node_it->stage_name) {
-                                throw std::runtime_error(
-                                    "Cannot mix source types. Project already has " + other_node.stage_name + 
-                                    " sources, cannot add " + node_it->stage_name + " TBC file."
-                                );
-                            }
-                        }
-                    }
-                    
-                    // Validate against project's source_format if set
-                    if (project.source_format_ != SourceType::Unknown) {
-                        bool is_yc_source = (node_it->stage_name.find("YC") != std::string::npos);
-                        SourceType expected_type = is_yc_source ? SourceType::YC : SourceType::Composite;
-                        
-                        if (expected_type != project.source_format_) {
-                            std::string expected_name = (project.source_format_ == SourceType::YC) ? "YC" : "Composite";
-                            std::string actual_name = is_yc_source ? "YC" : "Composite";
-                            throw std::runtime_error(
-                                "Source type mismatch. Project is configured for " + expected_name + 
-                                " sources, but attempting to add " + actual_name + " source (" + 
-                                node_it->stage_name + ")."
-                            );
-                        }
-                    }
-                } catch (const std::exception& e) {
-                    throw std::runtime_error(
-                        std::string("Failed to validate TBC file: ") + e.what()
-                    );
+                        "Failed to validate TBC file: metadata file not found (expected "
+                        + db_path + " or " + json_path + ")");
                 }
             }
         }

--- a/orc/core/stages/ld_sink/ld_sink_stage.cpp
+++ b/orc/core/stages/ld_sink/ld_sink_stage.cpp
@@ -11,7 +11,7 @@
 #include "stage_registry.h"
 #include "preview_renderer.h"
 #include "preview_helpers.h"
-#include "tbc_metadata_writer.h"
+#include <tbc_metadata_writer.h>
 #include "buffered_file_io.h"
 #include "logging.h"
 #include "biphase_observer.h"

--- a/orc/core/stages/ld_sink/ld_sink_stage.h
+++ b/orc/core/stages/ld_sink/ld_sink_stage.h
@@ -14,7 +14,7 @@
 #include "stage_parameter.h"
 #include <node_type.h>
 #include "video_field_representation.h"
-#include "../../tbc_source_internal/tbc_metadata.h"
+#include <tbc_metadata.h>
 #include "../triggerable_stage.h"
 #include "previewable_stage.h"
 #include "observation_context.h"

--- a/orc/core/stages/ntsc_comp_source/ntsc_comp_source_stage.cpp
+++ b/orc/core/stages/ntsc_comp_source/ntsc_comp_source_stage.cpp
@@ -16,7 +16,6 @@
 #include <stage_registry.h>
 #include <stdexcept>
 #include <fstream>
-#include <filesystem>
 
 namespace orc {
 
@@ -57,19 +56,6 @@ std::vector<ArtifactPtr> NTSCCompSourceStage::execute(
         db_path = input_path + ".db";
     }
 
-    // Check for legacy JSON metadata (produced by older ld-decode/vhs-decode)
-    if (!std::filesystem::exists(db_path) &&
-            db_path.size() > 3 && db_path.compare(db_path.size() - 3, 3, ".db") == 0) {
-        std::string json_path = db_path.substr(0, db_path.size() - 3) + ".json";
-        if (std::filesystem::exists(json_path)) {
-            throw UserDataError(
-                "TBC source has legacy JSON metadata and cannot be loaded. "
-                "Please update your decoder to a recent version with SQLite support and decode again "
-                "(recommended) or run ld-json-converter on the old JSON file (not recommended)"
-            );
-        }
-    }
-    
     // Get optional PCM audio path
     std::string pcm_path;
     auto pcm_path_it = parameters.find("pcm_path");

--- a/orc/core/stages/ntsc_yc_source/ntsc_yc_source_stage.cpp
+++ b/orc/core/stages/ntsc_yc_source/ntsc_yc_source_stage.cpp
@@ -16,7 +16,6 @@
 #include <stage_registry.h>
 #include <stdexcept>
 #include <fstream>
-#include <filesystem>
 
 namespace orc {
 
@@ -65,19 +64,6 @@ std::vector<ArtifactPtr> NTSCYCSourceStage::execute(
         db_path = y_path + ".db";
     }
 
-    // Check for legacy JSON metadata (produced by older ld-decode/vhs-decode)
-    if (!std::filesystem::exists(db_path) &&
-            db_path.size() > 3 && db_path.compare(db_path.size() - 3, 3, ".db") == 0) {
-        std::string json_path = db_path.substr(0, db_path.size() - 3) + ".json";
-        if (std::filesystem::exists(json_path)) {
-            throw UserDataError(
-                "TBC source has legacy JSON metadata and cannot be loaded. "
-                "Please update your decoder to a recent version with SQLite support and decode again "
-                "(recommended) or run ld-json-converter on the old JSON file (not recommended)"
-            );
-        }
-    }
-    
     // Get optional PCM audio path
     std::string pcm_path;
     auto pcm_path_it = parameters.find("pcm_path");

--- a/orc/core/stages/pal_comp_source/pal_comp_source_stage.cpp
+++ b/orc/core/stages/pal_comp_source/pal_comp_source_stage.cpp
@@ -16,7 +16,6 @@
 #include <stage_registry.h>
 #include <stdexcept>
 #include <fstream>
-#include <filesystem>
 
 namespace orc {
 
@@ -57,19 +56,6 @@ std::vector<ArtifactPtr> PALCompSourceStage::execute(
         db_path = input_path + ".db";
     }
 
-    // Check for legacy JSON metadata (produced by older ld-decode/vhs-decode)
-    if (!std::filesystem::exists(db_path) &&
-            db_path.size() > 3 && db_path.compare(db_path.size() - 3, 3, ".db") == 0) {
-        std::string json_path = db_path.substr(0, db_path.size() - 3) + ".json";
-        if (std::filesystem::exists(json_path)) {
-            throw UserDataError(
-                "TBC source has legacy JSON metadata and cannot be loaded. "
-                "Please update your decoder to a recent version with SQLite support and decode again "
-                "(recommended) or run ld-json-converter on the old JSON file (not recommended)"
-            );
-        }
-    }
-    
     // Get optional PCM audio path
     std::string pcm_path;
     auto pcm_path_it = parameters.find("pcm_path");

--- a/orc/core/stages/pal_yc_source/pal_yc_source_stage.cpp
+++ b/orc/core/stages/pal_yc_source/pal_yc_source_stage.cpp
@@ -16,7 +16,6 @@
 #include <stage_registry.h>
 #include <stdexcept>
 #include <fstream>
-#include <filesystem>
 
 namespace orc {
 
@@ -65,19 +64,6 @@ std::vector<ArtifactPtr> PALYCSourceStage::execute(
         db_path = y_path + ".db";
     }
 
-    // Check for legacy JSON metadata (produced by older ld-decode/vhs-decode)
-    if (!std::filesystem::exists(db_path) &&
-            db_path.size() > 3 && db_path.compare(db_path.size() - 3, 3, ".db") == 0) {
-        std::string json_path = db_path.substr(0, db_path.size() - 3) + ".json";
-        if (std::filesystem::exists(json_path)) {
-            throw UserDataError(
-                "TBC source has legacy JSON metadata and cannot be loaded. "
-                "Please update your decoder to a recent version with SQLite support and decode again "
-                "(recommended) or run ld-json-converter on the old JSON file (not recommended)"
-            );
-        }
-    }
-    
     // Get optional PCM audio path
     std::string pcm_path;
     auto pcm_path_it = parameters.find("pcm_path");

--- a/orc/core/tbc_source_internal/tbc_audio_efm_handler.h
+++ b/orc/core/tbc_source_internal/tbc_audio_efm_handler.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "video_field_representation.h"
-#include "../tbc_source_internal/tbc_metadata.h"
+#include <tbc_metadata.h>
 #include "buffered_file_io.h"
 #include <memory>
 #include <mutex>

--- a/orc/core/tbc_source_internal/tbc_video_field_representation.h
+++ b/orc/core/tbc_source_internal/tbc_video_field_representation.h
@@ -12,7 +12,7 @@
 
 #include "video_field_representation.h"
 #include "tbc_reader.h"
-#include "tbc_metadata.h"
+#include <itbc_metadata_reader.h>
 #include "tbc_audio_efm_handler.h"
 #include "lru_cache.h"
 #include "buffered_file_io.h"
@@ -67,7 +67,7 @@ public:
      */
     TBCVideoFieldRepresentation(
         std::shared_ptr<TBCReader> tbc_reader,
-        std::shared_ptr<TBCMetadataReader> metadata_reader,
+        std::shared_ptr<ITBCMetadataReader> metadata_reader,
         ArtifactID artifact_id,
         Provenance provenance
     );
@@ -138,13 +138,13 @@ private:
     // Only observers and the source stage itself should access TBC internals
     // Other stages must use the standard VideoFieldRepresentation interface
     const SourceParameters& video_parameters() const { return video_params_; }
-    std::shared_ptr<TBCMetadataReader> get_metadata_reader() const { return metadata_reader_; }
+    std::shared_ptr<ITBCMetadataReader> get_metadata_reader() const { return metadata_reader_; }
     std::optional<FieldMetadata> get_field_metadata(FieldID id) const override;
     
     // TODO: Observer system refactored - observers now access data via public interface
     
     std::shared_ptr<TBCReader> tbc_reader_;
-    std::shared_ptr<TBCMetadataReader> metadata_reader_;
+    std::shared_ptr<ITBCMetadataReader> metadata_reader_;
     
     SourceParameters video_params_;
     std::map<FieldID, FieldMetadata> field_metadata_cache_;
@@ -153,7 +153,7 @@ private:
     std::unique_ptr<TBCAudioEFMHandler> audio_efm_handler_;
     
     // Access to metadata reader for internal use only
-    const TBCMetadataReader* metadata_reader() const { return metadata_reader_.get(); }
+    const ITBCMetadataReader* metadata_reader() const { return metadata_reader_.get(); }
     
     // Line data cache (for get_line calls)
     // Cache size: 500 fields × ~1.4MB/field = ~700MB max for preview navigation

--- a/orc/core/tbc_source_internal/tbc_yc_video_field_representation.h
+++ b/orc/core/tbc_source_internal/tbc_yc_video_field_representation.h
@@ -13,7 +13,7 @@
 
 #include "video_field_representation.h"
 #include "tbc_reader.h"
-#include "tbc_metadata.h"
+#include <itbc_metadata_reader.h>
 #include "tbc_audio_efm_handler.h"
 #include "lru_cache.h"
 #include "buffered_file_io.h"
@@ -85,7 +85,7 @@ public:
     TBCYCVideoFieldRepresentation(
         std::shared_ptr<TBCReader> y_reader,
         std::shared_ptr<TBCReader> c_reader,
-        std::shared_ptr<TBCMetadataReader> metadata_reader,
+        std::shared_ptr<ITBCMetadataReader> metadata_reader,
         ArtifactID artifact_id,
         Provenance provenance
     );
@@ -158,14 +158,14 @@ public:
 private:
     // TBC-specific accessors - private to enforce architectural boundaries
     const SourceParameters& video_parameters() const { return video_params_; }
-    std::shared_ptr<TBCMetadataReader> get_metadata_reader() const { return metadata_reader_; }
+    std::shared_ptr<ITBCMetadataReader> get_metadata_reader() const { return metadata_reader_; }
     std::optional<FieldMetadata> get_field_metadata(FieldID id) const override;
     
     // TODO: Observer system refactored - observers now access data via public interface
     
     std::shared_ptr<TBCReader> y_reader_;  // Luma channel reader
     std::shared_ptr<TBCReader> c_reader_;  // Chroma channel reader
-    std::shared_ptr<TBCMetadataReader> metadata_reader_;
+    std::shared_ptr<ITBCMetadataReader> metadata_reader_;
     
     SourceParameters video_params_;
     std::map<FieldID, FieldMetadata> field_metadata_cache_;

--- a/orc/core/tbc_video_field_representation.cpp
+++ b/orc/core/tbc_video_field_representation.cpp
@@ -11,6 +11,7 @@
 #include "tbc_source_internal/tbc_video_field_representation.h"
 #include "dropout_decision.h"
 #include "logging.h"
+#include <open_tbc_metadata.h>
 #include <sstream>
 #include <chrono>
 
@@ -18,7 +19,7 @@ namespace orc {
 
 TBCVideoFieldRepresentation::TBCVideoFieldRepresentation(
     std::shared_ptr<TBCReader> tbc_reader,
-    std::shared_ptr<TBCMetadataReader> metadata_reader,
+    std::shared_ptr<ITBCMetadataReader> metadata_reader,
     ArtifactID artifact_id,
     Provenance provenance
 ) : VideoFieldRepresentation(std::move(artifact_id), std::move(provenance)),
@@ -253,10 +254,10 @@ std::shared_ptr<TBCVideoFieldRepresentation> create_tbc_representation(
 ) {
     // Create readers
     auto tbc_reader = std::make_shared<TBCReader>();
-    auto metadata_reader = std::make_shared<TBCMetadataReader>();
-    
+    auto metadata_reader = std::shared_ptr<ITBCMetadataReader>(open_tbc_metadata(metadata_filename));
+
     // Open metadata first to get parameters
-    if (!metadata_reader->open(metadata_filename)) {
+    if (!metadata_reader) {
         ORC_LOG_ERROR("Failed to open TBC metadata: {}", metadata_filename);
         return nullptr;
     }

--- a/orc/core/tbc_yc_video_field_representation.cpp
+++ b/orc/core/tbc_yc_video_field_representation.cpp
@@ -11,6 +11,7 @@
 #include "tbc_source_internal/tbc_yc_video_field_representation.h"
 #include "dropout_decision.h"
 #include "logging.h"
+#include <open_tbc_metadata.h>
 #include <sstream>
 #include <chrono>
 
@@ -19,7 +20,7 @@ namespace orc {
 TBCYCVideoFieldRepresentation::TBCYCVideoFieldRepresentation(
     std::shared_ptr<TBCReader> y_reader,
     std::shared_ptr<TBCReader> c_reader,
-    std::shared_ptr<TBCMetadataReader> metadata_reader,
+    std::shared_ptr<ITBCMetadataReader> metadata_reader,
     ArtifactID artifact_id,
     Provenance provenance
 ) : VideoFieldRepresentation(std::move(artifact_id), std::move(provenance)),
@@ -363,10 +364,10 @@ std::shared_ptr<TBCYCVideoFieldRepresentation> create_tbc_yc_representation(
     // Create readers
     auto y_reader = std::make_shared<TBCReader>();
     auto c_reader = std::make_shared<TBCReader>();
-    auto metadata_reader = std::make_shared<TBCMetadataReader>();
-    
+    auto metadata_reader = std::shared_ptr<ITBCMetadataReader>(open_tbc_metadata(metadata_filename));
+
     // Open metadata first to get parameters
-    if (!metadata_reader->open(metadata_filename)) {
+    if (!metadata_reader) {
         ORC_LOG_ERROR("Failed to open TBC metadata: {}", metadata_filename);
         return nullptr;
     }

--- a/orc/gui/mainwindow.cpp
+++ b/orc/gui/mainwindow.cpp
@@ -1110,15 +1110,24 @@ void MainWindow::quickProject(const QString& filename)
         // Check for legacy JSON metadata produced by older ld-decode/vhs-decode
         QString json_path = base_path + ".tbc.json";
         if (QFileInfo::exists(json_path)) {
-            QMessageBox::warning(this, "Legacy Metadata Format",
-                "TBC source has legacy JSON metadata and cannot be loaded. "
-                "Please update your decoder to a recent version with SQLite support and decode again "
-                "(recommended) or run ld-json-converter on the old JSON file (not recommended)");
+            const QString filename = QFileInfo(json_path).fileName();
+            QMessageBox msgBox(this);
+            msgBox.setWindowTitle("Legacy Metadata Format");
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setText(QString("The TBC source '%1' has legacy JSON metadata. It will be read directly.\n\n"
+                                   "For best long-term results, consider re-decoding with a current version of ld-decode/vhs-decode.")
+                               .arg(filename));
+            QPushButton* continueBtn = msgBox.addButton("Continue", QMessageBox::AcceptRole);
+            msgBox.addButton("Cancel", QMessageBox::RejectRole);
+            msgBox.setDefaultButton(continueBtn);
+            msgBox.exec();
+            if (msgBox.clickedButton() != continueBtn) return;
+            // User chose Continue; fall through to load with JSON backend
+        } else {
+            QMessageBox::warning(this, "Missing Metadata File",
+                QString("Metadata file not found:\n%1\n\nRe-run the decoder to generate a .tbc.db metadata file.").arg(db_path));
             return;
         }
-        QMessageBox::warning(this, "Missing Metadata File", 
-            QString("Could not find metadata file: %1").arg(db_path));
-        return;
     }
     
     // Read metadata to determine video format (NTSC or PAL)

--- a/orc/gui/stageparameterdialog.cpp
+++ b/orc/gui/stageparameterdialog.cpp
@@ -563,11 +563,18 @@ bool StageParameterDialog::validate_values()
         if (db_path.endsWith(".db", Qt::CaseInsensitive)) {
             QString json_path = db_path.left(db_path.length() - 3) + ".json";
             if (QFileInfo::exists(json_path)) {
-                QMessageBox::warning(this, "Legacy Metadata Format",
-                    "TBC source has legacy JSON metadata and cannot be loaded. "
-                    "Please update your decoder to a recent version with SQLite support and decode again "
-                    "(recommended) or run ld-json-converter on the old JSON file (not recommended)");
-                return false;
+                const QString filename = QFileInfo(json_path).fileName();
+                QMessageBox msgBox(this);
+                msgBox.setWindowTitle("Legacy Metadata Format");
+                msgBox.setIcon(QMessageBox::Warning);
+                msgBox.setText(QString("The TBC source '%1' has legacy JSON metadata. It will be read directly.\n\n"
+                                       "For best long-term results, consider re-decoding with a current version of ld-decode/vhs-decode.")
+                                   .arg(filename));
+                QPushButton* continueBtn = msgBox.addButton("Continue", QMessageBox::AcceptRole);
+                msgBox.addButton("Cancel", QMessageBox::RejectRole);
+                msgBox.setDefaultButton(continueBtn);
+                msgBox.exec();
+                return msgBox.clickedButton() == continueBtn;
             }
         }
         QMessageBox::warning(this, "Missing Metadata File",

--- a/orc/presenters/src/project_presenter.cpp
+++ b/orc/presenters/src/project_presenter.cpp
@@ -15,7 +15,7 @@
 #include "../core/include/stage_parameter.h"
 #include "../core/include/logging.h"
 #include "../core/stages/triggerable_stage.h"
-#include "../core/tbc_source_internal/tbc_metadata.h"   // for TBCMetaDataReader
+#include <open_tbc_metadata.h>  // for open_tbc_metadata (handles .tbc.db and legacy .tbc.json)
 #include <stdexcept>
 #include <algorithm>
 
@@ -66,14 +66,14 @@ std::optional<orc::SourceParameters> ProjectPresenter::readVideoParameters(
     const std::string& metadata_path)
 {
     try {
-        orc::TBCMetadataReader reader;
-        if (!reader.open(metadata_path)) {
+        auto reader = orc::open_tbc_metadata(metadata_path);
+        if (!reader) {
             ORC_LOG_WARN("Failed to open metadata file: {}", metadata_path);
             return std::nullopt;
         }
         
-        auto params = reader.read_video_parameters();
-        reader.close();
+        auto params = reader->read_video_parameters();
+        reader->close();
         return params;
     } catch (const std::exception& e) {
         ORC_LOG_ERROR("Exception reading metadata from {}: {}", metadata_path, e.what());


### PR DESCRIPTION
Added support for loading JSON metadata as a fallback from SQLite and moved metadata handling into it's own library for ease of maintenance

## Summary

Briefly describe what this PR changes and why.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

Tested via orc-gui loading legacy and current TBC projects

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)

## Related issue

None