### PR TITLE
fixed MSVC 2022 build

### DIFF
--- a/orc-unit-tests/core/CMakeLists.txt
+++ b/orc-unit-tests/core/CMakeLists.txt
@@ -22,7 +22,6 @@ add_executable(
 target_link_libraries(
         orc-core-unit-tests
         orc-core
-        GTest::gtest_main
         GTest::gmock_main
 )
 

--- a/orc/core/CMakeLists.txt
+++ b/orc/core/CMakeLists.txt
@@ -15,7 +15,11 @@ list(REMOVE_ITEM EFM_DECODER_SOURCES
 # Also force -O2 on these files even in Debug builds: the EFM pipeline is the
 # dominant CPU cost and STL template code at -O0 is the primary slowdown.  GCC/Clang
 # honour the last -O flag, so -O2 here overrides the target-level -O0.
-set_source_files_properties(${EFM_DECODER_SOURCES} PROPERTIES COMPILE_FLAGS "-w -O2")
+if(MSVC)
+    # MSVC barfs if -O2 is passed in
+else()
+    set_source_files_properties(${EFM_DECODER_SOURCES} PROPERTIES COMPILE_FLAGS "-w -O2")
+endif()
 
 add_library(orc-core STATIC
     # Phase 1: Foundations

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,8 @@
     "sqlite3",
     "libpng",
     "fftw3",
-    "pkgconf"
+    "pkgconf",
+    "ffmpeg",
+    "gtest"
   ]
 }


### PR DESCRIPTION
## Summary

Fixed Visual Studio 2022 build when using vcpkg.json

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

I built successfully using Visual Studio 2022 in Windows.

## Checklist

- [ ] Scope is focused and minimal
- [ ] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)

## Related issue

Closes #