### PR TITLE
Implement PAL-M support according to issue #145

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -172,6 +172,19 @@ The project targets ~80% unit test coverage with these principles:
 - **Integration tests:** Sparse; reserved for happy-path wiring checks only.
 - **Mocks:** Use Google Test `MOCK_METHOD` framework on interfaces (not classes).
 
+### ⚠️ CRITICAL: Unit Test Constraints (Non-Negotiable)
+
+**Unit tests MUST NOT access the filesystem, network, database, or system clock under ANY circumstances.** This is enforced in code review:
+
+- ❌ **Forbidden:** Creating temp files, reading JSON/YAML files, loading config files, accessing any external resource
+- ❌ **Forbidden:** Directly calling code that touches disk/network (even "just to test happy path")
+- ✅ **Required:** Mock ALL external dependencies via interfaces; inject mocks into the class under test
+- ✅ **Required:** Test the class's logic in isolation; verify calls to dependencies, not the dependencies' behavior
+
+**Example:** When testing metadata parsing logic that handles both "PAL_M" and "PAL-M" format names, do NOT read real JSON files. Instead, mock the metadata reader interface and feed it expected format-name strings directly through mocked method calls.
+
+See [TESTING.md](../TESTING.md) "Unit tests" section and examples like `daphne_vbi_writer_util_test.cpp` for how to structure tests with proper mocking.
+
 **When adding/changing behavior:**
 1. Write or update unit tests first.
 2. Mock external dependencies (file I/O, network, etc.).

--- a/orc-tests/core/unit/CMakeLists.txt
+++ b/orc-tests/core/unit/CMakeLists.txt
@@ -60,6 +60,7 @@ orc_add_core_unit_tests(
         stages/chroma_sink/monodecoder_test.cpp
         stages/chroma_sink/ntsc_pal_decoder_wrapper_test.cpp
         stages/chroma_sink/palcolour_test.cpp
+        stages/chroma_sink/pal_m_integration_test.cpp
         stages/chroma_sink/raw_video_sink_stage_test.cpp
         stages/chroma_sink/sourcefield_test.cpp
         stages/daphne_vbi_sink/daphne_vbi_writer_util_test.cpp
@@ -83,6 +84,13 @@ orc_add_core_unit_tests(
         contracts/public_stage_contract_test.cpp
         contracts/stage_registry_contract_test.cpp
         contracts/project_to_dag_contract_test.cpp
+)
+
+orc_add_core_unit_tests(
+        orc-core-unit-tests-metadata
+        "unit"
+
+        metadata/video_system_parsing_test.cpp
 )
 
         orc_add_core_unit_tests(

--- a/orc-tests/core/unit/metadata/video_system_parsing_test.cpp
+++ b/orc-tests/core/unit/metadata/video_system_parsing_test.cpp
@@ -1,0 +1,64 @@
+/*
+ * File:        video_system_parsing_test.cpp
+ * Module:      orc-core unit tests
+ * Purpose:     Unit tests for video system name parsing with SQLite vs JSON constraints
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ */
+
+#include <gtest/gtest.h>
+#include <tbc_metadata.h>
+
+// Note: lddecodemetadata.h is internal/private and not exported via public headers.
+// parseVideoSystemName() is declared in lddecodemetadata.h but cannot be included here
+// without adding a public forward declaration or exposing internals.
+// For this test suite, we focus on testing video_system_from_string() which is the
+// public-facing function for SQLite metadata parsing.
+// The JSON fallback parsing is tested indirectly through the JSON reader integration.
+
+namespace orc {
+
+// Tests for video_system_from_string() - used for SQLite metadata
+// SQLite should only accept the canonical "PAL_M" (underscore) form
+class VideoSystemFromStringTest : public ::testing::Test {
+};
+
+TEST_F(VideoSystemFromStringTest, AcceptsCanonicalPal) {
+    EXPECT_EQ(video_system_from_string("PAL"), VideoSystem::PAL);
+}
+
+TEST_F(VideoSystemFromStringTest, AcceptsCanonicalNtsc) {
+    EXPECT_EQ(video_system_from_string("NTSC"), VideoSystem::NTSC);
+}
+
+TEST_F(VideoSystemFromStringTest, AcceptsCanonicalPalM) {
+    EXPECT_EQ(video_system_from_string("PAL_M"), VideoSystem::PAL_M);
+}
+
+TEST_F(VideoSystemFromStringTest, RejectsHyphenatedPalM) {
+    // SQLite uses only the canonical underscore form
+    // This enforces that SQLite metadata must use "PAL_M" not "PAL-M"
+    EXPECT_EQ(video_system_from_string("PAL-M"), VideoSystem::Unknown);
+}
+
+TEST_F(VideoSystemFromStringTest, RejectsUnknownFormat) {
+    EXPECT_EQ(video_system_from_string("SECAM"), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string("PAL_L"), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string(""), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string("pal_m"), VideoSystem::Unknown);  // case-sensitive
+}
+
+TEST_F(VideoSystemFromStringTest, SqliteOnlyAcceptsExactCanonicalForm) {
+    // This test enforces the strict requirement:
+    // SQLite metadata must use exactly "PAL_M" (underscore, uppercase)
+    // No variations like "PAL-M", "pal_m", "Pal_M" are accepted
+    
+    EXPECT_NE(video_system_from_string("PAL_M"), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string("PAL-M"), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string("pal_m"), VideoSystem::Unknown);
+    EXPECT_EQ(video_system_from_string("Pal_M"), VideoSystem::Unknown);
+}
+
+}  // namespace orc
+

--- a/orc-tests/core/unit/preview_types/preview_helpers_yc_combine_test.cpp
+++ b/orc-tests/core/unit/preview_types/preview_helpers_yc_combine_test.cpp
@@ -61,6 +61,7 @@ public:
         d.field_id = id;
         d.parity = (id.value() % 2 == 0) ? orc::FieldParity::Top : orc::FieldParity::Bottom;
         d.format = orc::VideoFormat::NTSC;
+        d.system = orc::VideoSystem::NTSC;
         d.width = static_cast<size_t>(params_.field_width);
         d.height = static_cast<size_t>(params_.field_height);
         return d;

--- a/orc-tests/core/unit/stages/chroma_sink/ffmpeg_video_sink_stage_test.cpp
+++ b/orc-tests/core/unit/stages/chroma_sink/ffmpeg_video_sink_stage_test.cpp
@@ -128,6 +128,39 @@ namespace orc_unit_test
         }
     }
 
+    TEST(FFmpegVideoSinkStageTest, decoderOptions_includePalPaths_forPalM_forCompositeAndYc)
+    {
+        orc::FFmpegVideoSinkStage stage;
+
+        for (const auto source_type : {orc::SourceType::Composite, orc::SourceType::YC}) {
+            auto descriptors = stage.get_parameter_descriptors(orc::VideoSystem::PAL_M, source_type);
+            const auto* decoder_type = find_parameter(descriptors, "decoder_type");
+
+            ASSERT_NE(decoder_type, nullptr);
+            const auto& allowed = decoder_type->constraints.allowed_strings;
+
+            ASSERT_TRUE(decoder_type->constraints.default_value.has_value());
+            ASSERT_TRUE(std::holds_alternative<std::string>(*decoder_type->constraints.default_value));
+            EXPECT_EQ(std::get<std::string>(*decoder_type->constraints.default_value), "pal2d");
+
+            EXPECT_FALSE(has_string(allowed, "auto"));
+            EXPECT_TRUE(has_string(allowed, "mono"));
+            EXPECT_TRUE(has_string(allowed, "pal2d"));
+            EXPECT_TRUE(has_string(allowed, "transform2d"));
+            EXPECT_TRUE(has_string(allowed, "transform3d"));
+            EXPECT_FALSE(has_string(allowed, "ntsc1d"));
+            EXPECT_FALSE(has_string(allowed, "ntsc2d"));
+            EXPECT_FALSE(has_string(allowed, "ntsc3d"));
+            EXPECT_FALSE(has_string(allowed, "ntsc3dnoadapt"));
+
+            if (source_type == orc::SourceType::YC) {
+                EXPECT_NE(decoder_type->description.find("YC sources"), std::string::npos);
+            } else {
+                EXPECT_EQ(decoder_type->description.find("YC sources"), std::string::npos);
+            }
+        }
+    }
+
     TEST(FFmpegVideoSinkStageTest, setParameters_rejectsRawOutputFormats)
     {
         orc::FFmpegVideoSinkStage stage;

--- a/orc-tests/core/unit/stages/chroma_sink/pal_m_integration_test.cpp
+++ b/orc-tests/core/unit/stages/chroma_sink/pal_m_integration_test.cpp
@@ -1,0 +1,307 @@
+/*
+ * File:        pal_m_integration_test.cpp
+ * Module:      orc-core-tests
+ * Purpose:     Integration test for PAL-M support across decoder pipeline
+ *
+ * Tests that PAL-M video parameters flow correctly through the shared
+ * PAL decoder path and produce valid output.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 decode-orc contributors
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <memory>
+#include <vector>
+
+#include "../../../../orc/core/stages/chroma_sink/decoders/paldecoder.h"
+#include "../../../../orc/core/stages/chroma_sink/decoders/palcolour.h"
+#include "../../../../orc/core/stages/chroma_sink/decoders/sourcefield.h"
+#include "../../../../orc/core/stages/chroma_sink/decoders/componentframe.h"
+
+namespace orc_unit_test
+{
+    namespace
+    {
+        // Create standard PAL-M video parameters matching Brazilian PAL-M specs
+        orc::SourceParameters make_pal_m_video_params()
+        {
+            orc::SourceParameters p;
+            p.system = orc::VideoSystem::PAL_M;
+            p.field_width = 909;
+            p.field_height = 263;
+            p.active_video_start = 16;
+            p.active_video_end = 893;
+            p.first_active_frame_line = 0;
+            p.last_active_frame_line = 520;  // 525 lines, -1 for 0-indexing adjustment
+            p.first_active_field_line = 0;
+            p.last_active_field_line = 262;
+            p.colour_burst_start = 16;
+            p.colour_burst_end = 110;
+            p.black_16b_ire = 0;
+            p.white_16b_ire = 100;
+            // PAL-M FSC and sample rate per official specs
+            p.sample_rate = 14318181.8181;  // 4 * FSC
+            p.fsc = 3575611.89;
+            p.active_area_cropping_applied = false;
+            return p;
+        }
+
+        // Create standard PAL video parameters for comparison
+        orc::SourceParameters make_pal_video_params()
+        {
+            orc::SourceParameters p;
+            p.system = orc::VideoSystem::PAL;
+            p.field_width = 909;
+            p.field_height = 313;
+            p.active_video_start = 16;
+            p.active_video_end = 893;
+            p.first_active_frame_line = 0;
+            p.last_active_frame_line = 620;
+            p.first_active_field_line = 0;
+            p.last_active_field_line = 312;
+            p.colour_burst_start = 16;
+            p.colour_burst_end = 110;
+            p.black_16b_ire = 0;
+            p.white_16b_ire = 100;
+            // Standard PAL FSC and sample rate
+            p.sample_rate = 17734472.0;  // 4 * FSC
+            p.fsc = 4433618.75;
+            p.active_area_cropping_applied = false;
+            return p;
+        }
+
+        // Create a simple YC test field with known patterns
+        SourceField make_pal_m_yc_test_field(bool is_first, uint16_t base_y, uint16_t base_c)
+        {
+            SourceField field;
+            field.is_yc = true;
+            field.is_first_field = is_first;
+
+            const int width = 909;
+            const int height = 263;
+
+            field.luma_data.resize(width * height, 0);
+            field.chroma_data.resize(width * height, 0);
+
+            // Fill with simple gradients to test processing
+            for (int line = 0; line < height; ++line) {
+                for (int x = 0; x < width; ++x) {
+                    int idx = line * width + x;
+                    // Simple gradient patterns
+                    field.luma_data[idx] = static_cast<uint16_t>(base_y + (line % 256));
+                    field.chroma_data[idx] = static_cast<uint16_t>(base_c + ((x % 4) * 16));
+                }
+            }
+
+            return field;
+        }
+    }
+
+    // =========================================================================
+    // PAL-M Decoder Configuration Tests
+    // =========================================================================
+
+    TEST(PalMIntegrationTest, palColourAcceptsPalM)
+    {
+        const auto params = make_pal_m_video_params();
+
+        // Create decoder with standard PAL configuration
+        PalColour::Configuration pal_config;
+        pal_config.chromaFilter = PalColour::palColourFilter;
+        PalColour decoder;
+
+        // Configure with PAL-M parameters
+        EXPECT_NO_THROW({
+            decoder.updateConfiguration(params, pal_config);
+        }) << "PalColour should accept PAL-M parameters";
+    }
+
+    // =========================================================================
+    // PAL-M vs PAL Parameter Validation Tests
+    // =========================================================================
+
+    TEST(PalMIntegrationTest, palMHasCorrectFieldHeight)
+    {
+        const auto pal_params = make_pal_video_params();
+        const auto pal_m_params = make_pal_m_video_params();
+
+        // PAL uses 625 lines (313 per field)
+        EXPECT_EQ(pal_params.field_height, 313);
+        EXPECT_EQ(pal_params.field_height * 2 - 1, 625);
+
+        // PAL-M uses 525 lines (263 per field, -1 adjustment)
+        EXPECT_EQ(pal_m_params.field_height, 263);
+        EXPECT_EQ(pal_m_params.field_height * 2 - 1, 525);
+    }
+
+    TEST(PalMIntegrationTest, palMHasCorrectFsc)
+    {
+        const auto pal_params = make_pal_video_params();
+        const auto pal_m_params = make_pal_m_video_params();
+
+        // PAL FSC ~4.43 MHz
+        EXPECT_NEAR(pal_params.fsc, 4433618.75, 100.0);
+
+        // PAL-M FSC ~3.58 MHz (distinct from PAL)
+        EXPECT_NEAR(pal_m_params.fsc, 3575611.89, 100.0);
+
+        // Verify they are distinctly different
+        EXPECT_NE(pal_params.fsc, pal_m_params.fsc);
+    }
+
+    // =========================================================================
+    // PAL-M Decoder Decoding Tests
+    // =========================================================================
+
+    TEST(PalMIntegrationTest, palColourDecodesYcFieldWithPalMParameters)
+    {
+        const auto params = make_pal_m_video_params();
+
+        PalColour::Configuration config;
+        config.chromaFilter = PalColour::palColourFilter;
+        config.chromaGain = 1.0;
+        config.chromaPhase = 0.0;
+        config.yNRLevel = 0.0;
+
+        PalColour decoder;
+        decoder.updateConfiguration(params, config);
+
+        // Create test fields
+        std::vector<SourceField> input_fields;
+        input_fields.push_back(make_pal_m_yc_test_field(true, 50, 64));
+        input_fields.push_back(make_pal_m_yc_test_field(false, 52, 64));
+
+        // Decode frames
+        std::vector<ComponentFrame> output_frames(1);
+        ASSERT_NO_THROW({
+            decoder.decodeFrames(input_fields, 0, 2, output_frames);
+        }) << "Decoding YC fields with PAL-M parameters should not throw";
+
+        // Verify output dimensions match input parameters
+        EXPECT_EQ(output_frames[0].getWidth(), params.field_width);
+        // Frame height = (field_height * 2) - 1 for interlaced
+        EXPECT_EQ(output_frames[0].getHeight(), (params.field_height * 2) - 1);
+    }
+
+    TEST(PalMIntegrationTest, palColourPreservesYcDataPath)
+    {
+        const auto params = make_pal_m_video_params();
+
+        PalColour::Configuration config;
+        config.chromaFilter = PalColour::palColourFilter;
+        config.yNRLevel = 0.0;
+
+        PalColour decoder;
+        decoder.updateConfiguration(params, config);
+
+        // Create test field with known luma values
+        std::vector<SourceField> input_fields;
+        input_fields.push_back(make_pal_m_yc_test_field(true, 100, 64));
+        input_fields.push_back(make_pal_m_yc_test_field(false, 102, 64));
+
+        std::vector<ComponentFrame> output_frames(1);
+        decoder.decodeFrames(input_fields, 0, 2, output_frames);
+
+        // In YC path, luma should be copied directly (not filtered)
+        // Sample a point in the active area
+        const double* y_data = output_frames[0].y(10);
+        ASSERT_NE(y_data, nullptr);
+
+        // Luma values should be in the expected range
+        for (int i = 16; i < 893; ++i) {  // active_video_start to active_video_end
+            double luma = y_data[i];
+            // Should be in the range of our test data (100-102 + line offset)
+            EXPECT_GT(luma, 50.0) << "Luma values should be preserved in YC path";
+            EXPECT_LT(luma, 250.0) << "Luma values should be in reasonable range";
+        }
+    }
+
+    // =========================================================================
+    // PAL-M Transform Filter Configuration Tests
+    // =========================================================================
+
+    TEST(PalMIntegrationTest, palColourSupportsTransform2dFilterWithPalM)
+    {
+        const auto params = make_pal_m_video_params();
+
+        PalColour::Configuration config;
+        config.chromaFilter = PalColour::transform2DFilter;
+        config.transformThreshold = 0.4;
+
+        PalColour decoder;
+        // Should configure without error
+        ASSERT_NO_THROW({
+            decoder.updateConfiguration(params, config);
+        }) << "PalColour should support Transform 2D filter with PAL-M";
+    }
+
+    TEST(PalMIntegrationTest, palColourSupportsTransform3dFilterWithPalM)
+    {
+        const auto params = make_pal_m_video_params();
+
+        PalColour::Configuration config;
+        config.chromaFilter = PalColour::transform3DFilter;
+        config.transformThreshold = 0.4;
+
+        PalColour decoder;
+        // Should configure without error
+        ASSERT_NO_THROW({
+            decoder.updateConfiguration(params, config);
+        }) << "PalColour should support Transform 3D filter with PAL-M";
+    }
+
+    // =========================================================================
+    // PAL-M vs PAL Comparative Tests
+    // =========================================================================
+
+    TEST(PalMIntegrationTest, palAndPalMDecoderConfigureIndependently)
+    {
+        const auto pal_params = make_pal_video_params();
+        const auto pal_m_params = make_pal_m_video_params();
+
+        PalColour::Configuration config;
+        config.chromaFilter = PalColour::palColourFilter;
+
+        PalColour decoder;
+
+        // Configure with PAL
+        EXPECT_NO_THROW({
+            decoder.updateConfiguration(pal_params, config);
+        }) << "Should configure with PAL parameters";
+
+        // Reconfigure with PAL-M
+        EXPECT_NO_THROW({
+            decoder.updateConfiguration(pal_m_params, config);
+        }) << "Should reconfigure with PAL-M parameters";
+
+        // Reconfigure back to PAL
+        EXPECT_NO_THROW({
+            decoder.updateConfiguration(pal_params, config);
+        }) << "Should reconfigure back to PAL parameters";
+    }
+
+    TEST(PalMIntegrationTest, palMDecoderLookAroundValuesMatchPal)
+    {
+        // PAL-M should have same look-behind/look-ahead as PAL
+        // since they share the same decoder implementation
+
+        PalColour::Configuration pal_config;
+        pal_config.chromaFilter = PalColour::palColourFilter;
+
+        PalColour pal_decoder;
+        pal_decoder.updateConfiguration(make_pal_video_params(), pal_config);
+        auto pal_look_behind = pal_decoder.getConfiguration().getLookBehind();
+        auto pal_look_ahead = pal_decoder.getConfiguration().getLookAhead();
+
+        PalColour pal_m_decoder;
+        pal_m_decoder.updateConfiguration(make_pal_m_video_params(), pal_config);
+        auto pal_m_look_behind = pal_m_decoder.getConfiguration().getLookBehind();
+        auto pal_m_look_ahead = pal_m_decoder.getConfiguration().getLookAhead();
+
+        // Should match since both use palColourFilter
+        EXPECT_EQ(pal_look_behind, pal_m_look_behind);
+        EXPECT_EQ(pal_look_ahead, pal_m_look_ahead);
+    }
+}

--- a/orc-tests/core/unit/stages/mask_line/mask_line_stage_test.cpp
+++ b/orc-tests/core/unit/stages/mask_line/mask_line_stage_test.cpp
@@ -130,6 +130,7 @@ namespace orc_unit_test
             orc::FieldID(0),
             orc::FieldParity::Top,
             orc::VideoFormat::NTSC,
+            orc::VideoSystem::NTSC,
             8,
             262,
             std::nullopt,

--- a/orc-tests/core/unit/stages/pal_comp_source/pal_comp_source_stage_test.cpp
+++ b/orc-tests/core/unit/stages/pal_comp_source/pal_comp_source_stage_test.cpp
@@ -9,13 +9,45 @@
  */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <algorithm>
 
+#include "../../include/video_field_representation_mock.h"
 #include "../../../../orc/core/stages/pal_comp_source/pal_comp_source_stage.h"
 #include "../../../../orc/core/include/observation_context.h"
+#include "../../../../../orc/common/include/error_types.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+using testing::StrictMock;
 
 namespace orc_unit_test
 {
+    class MockPALCompSourceLoader : public orc::IPALCompSourceLoader
+    {
+    public:
+        MOCK_METHOD(
+            std::shared_ptr<orc::VideoFieldRepresentation>,
+            load,
+            (const std::string& input_path,
+             const std::string& db_path,
+             const std::string& pcm_path,
+             const std::string& efm_path),
+            (const, override));
+    };
+
+    orc::SourceParameters make_pal_family_comp_source_parameters(orc::VideoSystem system)
+    {
+        orc::SourceParameters params;
+        params.system = system;
+        params.decoder = "ld-decode";
+        params.field_width = 909;
+        params.field_height = (system == orc::VideoSystem::PAL) ? 313 : 263;
+        params.number_of_sequential_fields = 1449;
+        return params;
+    }
+
     // =========================================================================
     // Stage interface invariants
     // =========================================================================
@@ -213,6 +245,104 @@ namespace orc_unit_test
         const auto outputs = stage.execute({}, {{"input_path", std::string("")}}, observation_context);
 
         EXPECT_TRUE(outputs.empty());
+    }
+
+    TEST(PALCompSourceStageTest, execute_loadsPalMRepresentationThroughInjectedLoader)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALCompSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::ObservationContext observation_context;
+        orc::PALCompSourceStage stage(loader);
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_comp_source_parameters(orc::VideoSystem::PAL_M)));
+
+        EXPECT_CALL(*loader, load("/tmp/source.tbc", "/tmp/source.tbc.db", "", ""))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        const auto outputs = stage.execute(
+            {},
+            {{"input_path", std::string("/tmp/source.tbc")}},
+            observation_context);
+
+        ASSERT_EQ(outputs.size(), 1u);
+        EXPECT_EQ(outputs.front(), std::static_pointer_cast<orc::Artifact>(representation));
+        EXPECT_TRUE(stage.supports_preview());
+    }
+
+    TEST(PALCompSourceStageTest, execute_throwsWhenLoadedMetadataIsNotPalFamily)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALCompSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::ObservationContext observation_context;
+        orc::PALCompSourceStage stage(loader);
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_comp_source_parameters(orc::VideoSystem::NTSC)));
+
+        EXPECT_CALL(*loader, load(_, _, _, _))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        EXPECT_THROW(
+            stage.execute(
+                {},
+                {{"input_path", std::string("/tmp/source.tbc")}},
+                observation_context),
+            orc::UserDataError);
+    }
+
+    TEST(PALCompSourceStageTest, generateReport_usesInjectedLoaderMetadataForPalM)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALCompSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::PALCompSourceStage stage(loader);
+
+        ASSERT_TRUE(stage.set_parameters({
+            {"input_path", std::string("/tmp/source.tbc")}
+        }));
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_comp_source_parameters(orc::VideoSystem::PAL_M)));
+        EXPECT_CALL(*representation, field_range())
+            .Times(1)
+            .WillOnce(Return(orc::FieldIDRange(orc::FieldID(0), orc::FieldID(2))));
+        EXPECT_CALL(*representation, get_audio_sample_count(orc::FieldID(0)))
+            .Times(1)
+            .WillOnce(Return(100u));
+        EXPECT_CALL(*representation, get_audio_sample_count(orc::FieldID(1)))
+            .Times(1)
+            .WillOnce(Return(200u));
+        EXPECT_CALL(*representation, get_efm_sample_count(orc::FieldID(0)))
+            .Times(1)
+            .WillOnce(Return(10u));
+        EXPECT_CALL(*representation, get_efm_sample_count(orc::FieldID(1)))
+            .Times(1)
+            .WillOnce(Return(20u));
+        EXPECT_CALL(*representation, has_audio())
+            .Times(1)
+            .WillOnce(Return(true));
+        EXPECT_CALL(*representation, has_efm())
+            .Times(1)
+            .WillOnce(Return(true));
+
+        EXPECT_CALL(*loader, load("/tmp/source.tbc", "/tmp/source.tbc.db", "", ""))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        const auto report = stage.generate_report();
+
+        ASSERT_TRUE(report.has_value());
+        EXPECT_EQ(report->summary, "PAL Source Status");
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_count")), 1449);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_width")), 909);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_height")), 263);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("audio_samples")), 300);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("efm_tvalues")), 30);
     }
 
 } // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/pal_yc_source/pal_yc_source_stage_test.cpp
+++ b/orc-tests/core/unit/stages/pal_yc_source/pal_yc_source_stage_test.cpp
@@ -9,13 +9,49 @@
  */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <algorithm>
 
+#include "../../include/video_field_representation_mock.h"
 #include "../../../../orc/core/stages/pal_yc_source/pal_yc_source_stage.h"
 #include "../../../../orc/core/include/observation_context.h"
+#include "../../../../../orc/common/include/error_types.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+using testing::StrictMock;
 
 namespace orc_unit_test
 {
+    class MockPALYCSourceLoader : public orc::IPALYCSourceLoader
+    {
+    public:
+        MOCK_METHOD(
+            std::shared_ptr<orc::VideoFieldRepresentation>,
+            load,
+            (const std::string& y_path,
+             const std::string& c_path,
+             const std::string& db_path,
+             const std::string& pcm_path,
+             const std::string& efm_path),
+            (const, override));
+    };
+
+    orc::SourceParameters make_pal_family_source_parameters(orc::VideoSystem system)
+    {
+        orc::SourceParameters params;
+        params.system = system;
+        params.decoder = "ld-chroma-decoder";
+        params.field_width = 909;
+        params.field_height = (system == orc::VideoSystem::PAL) ? 313 : 263;
+        params.number_of_sequential_fields = 1449;
+        params.fsc = (system == orc::VideoSystem::PAL)
+            ? 4433618.75
+            : 3575611.89;
+        return params;
+    }
+
     // =========================================================================
     // Stage interface invariants
     // =========================================================================
@@ -276,6 +312,88 @@ namespace orc_unit_test
         const auto outputs = stage.execute({}, {{"y_path", std::string("y.tbcy")}}, observation_context);
 
         EXPECT_TRUE(outputs.empty());
+    }
+
+    TEST(PALYCSourceStageTest, execute_loadsPalMRepresentationThroughInjectedLoader)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALYCSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::ObservationContext observation_context;
+        orc::PALYCSourceStage stage(loader);
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_source_parameters(orc::VideoSystem::PAL_M)));
+
+        EXPECT_CALL(*loader, load("/tmp/source.tbcy", "/tmp/source.tbcc", "/tmp/source.tbcy.db", "", ""))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        const auto outputs = stage.execute(
+            {},
+            {
+                {"y_path", std::string("/tmp/source.tbcy")},
+                {"c_path", std::string("/tmp/source.tbcc")}
+            },
+            observation_context);
+
+        ASSERT_EQ(outputs.size(), 1u);
+        EXPECT_EQ(outputs.front(), std::static_pointer_cast<orc::Artifact>(representation));
+        EXPECT_TRUE(stage.supports_preview());
+    }
+
+    TEST(PALYCSourceStageTest, execute_throwsWhenLoadedMetadataIsNotPalFamily)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALYCSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::ObservationContext observation_context;
+        orc::PALYCSourceStage stage(loader);
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_source_parameters(orc::VideoSystem::NTSC)));
+
+        EXPECT_CALL(*loader, load(_, _, _, _, _))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        EXPECT_THROW(
+            stage.execute(
+                {},
+                {
+                    {"y_path", std::string("/tmp/source.tbcy")},
+                    {"c_path", std::string("/tmp/source.tbcc")}
+                },
+                observation_context),
+            orc::UserDataError);
+    }
+
+    TEST(PALYCSourceStageTest, generateReport_usesInjectedLoaderMetadataForPalM)
+    {
+        auto loader = std::make_shared<StrictMock<MockPALYCSourceLoader>>();
+        auto representation = std::make_shared<NiceMock<MockVideoFieldRepresentation>>();
+        orc::PALYCSourceStage stage(loader);
+
+        ASSERT_TRUE(stage.set_parameters({
+            {"y_path", std::string("/tmp/source.tbcy")},
+            {"c_path", std::string("/tmp/source.tbcc")}
+        }));
+
+        EXPECT_CALL(*representation, get_video_parameters())
+            .Times(1)
+            .WillOnce(Return(make_pal_family_source_parameters(orc::VideoSystem::PAL_M)));
+
+        EXPECT_CALL(*loader, load("/tmp/source.tbcy", "/tmp/source.tbcc", "/tmp/source.tbcy.db", "", ""))
+            .Times(1)
+            .WillOnce(Return(std::static_pointer_cast<orc::VideoFieldRepresentation>(representation)));
+
+        const auto report = stage.generate_report();
+
+        ASSERT_TRUE(report.has_value());
+        EXPECT_EQ(report->summary, "PAL YC Source Status");
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_count")), 1449);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_width")), 909);
+        EXPECT_EQ(std::get<int64_t>(report->metrics.at("field_height")), 263);
     }
 
 } // namespace orc_unit_test

--- a/orc-tests/core/unit/stages/video_params/video_params_stage_test.cpp
+++ b/orc-tests/core/unit/stages/video_params/video_params_stage_test.cpp
@@ -137,6 +137,62 @@ namespace orc_unit_test
         EXPECT_EQ(overridden->white_16b_ire, 50000);
     }
 
+    TEST(VideoParamsStageTest, process_preservesPalVideoSystem)
+    {
+        orc::VideoParamsStage stage;
+        auto source = std::make_shared<testing::NiceMock<MockVideoFieldRepresentation>>();
+        orc::SourceParameters source_params;
+        source_params.system = orc::VideoSystem::PAL;
+        source_params.field_width = 922;
+        source_params.field_height = 313;
+        source_params.first_active_field_line = 22;
+        source_params.last_active_field_line = 310;
+
+        EXPECT_CALL(*source, get_video_parameters()).WillRepeatedly(Return(source_params));
+        ASSERT_TRUE(stage.set_parameters({{"activeVideoStart", int32_t(120)}}));
+
+        const auto result = stage.process(source);
+
+        ASSERT_NE(result, nullptr);
+        const auto overridden = result->get_video_parameters();
+        ASSERT_TRUE(overridden.has_value());
+        EXPECT_EQ(overridden->system, orc::VideoSystem::PAL);
+        EXPECT_EQ(overridden->first_active_field_line, 22);
+        EXPECT_EQ(overridden->last_active_field_line, 310);
+    }
+
+    TEST(VideoParamsStageTest, process_preservesPalMVideoSystem)
+    {
+        orc::VideoParamsStage stage;
+        auto source = std::make_shared<testing::NiceMock<MockVideoFieldRepresentation>>();
+        orc::SourceParameters source_params;
+        source_params.system = orc::VideoSystem::PAL_M;
+        source_params.field_width = 844;
+        source_params.field_height = 262;
+        source_params.first_active_field_line = 20;
+        source_params.last_active_field_line = 259;
+        source_params.black_16b_ire = 0;
+        source_params.white_16b_ire = 65535;
+
+        EXPECT_CALL(*source, get_video_parameters()).WillRepeatedly(Return(source_params));
+        // Override only the first active field line, keeping other PAL-M defaults
+        ASSERT_TRUE(stage.set_parameters({{"firstActiveFieldLine", int32_t(21)}}));
+
+        const auto result = stage.process(source);
+
+        ASSERT_NE(result, nullptr);
+        const auto overridden = result->get_video_parameters();
+        ASSERT_TRUE(overridden.has_value());
+        // Verify PAL-M system is preserved
+        EXPECT_EQ(overridden->system, orc::VideoSystem::PAL_M);
+        // Verify override was applied
+        EXPECT_EQ(overridden->first_active_field_line, 21);
+        // Verify non-overridden PAL-M defaults are preserved
+        EXPECT_EQ(overridden->last_active_field_line, 259);
+        EXPECT_EQ(overridden->black_16b_ire, 0);
+        EXPECT_EQ(overridden->white_16b_ire, 65535);
+    }
+
     TEST(VideoParamsStageTest, execute_throwsWhenInputMissing)
     {
         orc::VideoParamsStage stage;

--- a/orc/core/include/video_field_representation.h
+++ b/orc/core/include/video_field_representation.h
@@ -47,6 +47,25 @@ enum class VideoFormat {
     Unknown
 };
 
+/**
+ * @brief Map an exact video system to the legacy coarse format bucket.
+ *
+ * Exact source identity should use VideoSystem. VideoFormat remains a
+ * compatibility bucket for existing PAL-vs-NTSC code paths.
+ */
+inline VideoFormat video_format_from_system(VideoSystem system) {
+    switch (system) {
+        case VideoSystem::PAL:
+        case VideoSystem::PAL_M:
+            return VideoFormat::PAL;
+        case VideoSystem::NTSC:
+            return VideoFormat::NTSC;
+        case VideoSystem::Unknown:
+        default:
+            return VideoFormat::Unknown;
+    }
+}
+
 // ============================================================================
 // Field Height Calculation Utilities
 // ============================================================================
@@ -165,6 +184,7 @@ struct FieldDescriptor {
     FieldID field_id;
     FieldParity parity;
     VideoFormat format;
+    VideoSystem system = VideoSystem::Unknown;
     size_t width;          // Samples per line
     size_t height;         // Number of lines
     

--- a/orc/core/metadata/include/tbc_metadata.h
+++ b/orc/core/metadata/include/tbc_metadata.h
@@ -30,6 +30,16 @@ namespace orc {
 // VideoSystem now defined in common_types.h
 
 std::string video_system_to_string(VideoSystem system);
+
+/**
+ * @brief Parse video system name from SQLite metadata.
+ * 
+ * For SQLite reads, the database should contain only "PAL_M" (underscore, canonical form).
+ * For fallback JSON that may use alternate forms, use parseVideoSystemName() instead.
+ * 
+ * @param name System name string ("PAL", "NTSC", or "PAL_M")
+ * @return VideoSystem enum value, or Unknown if not recognized
+ */
 VideoSystem video_system_from_string(const std::string& name);
 
 /**

--- a/orc/core/metadata/lddecodemetadata.cpp
+++ b/orc/core/metadata/lddecodemetadata.cpp
@@ -88,6 +88,7 @@ static const VideoSystemDefaults &getSystemDefaults(const LdDecodeMetaData::Vide
 
 // Look up a video system by name.
 // Return true and set system if found; if not found, return false.
+// For PAL-M, both "PAL_M" (underscore, from ld-decode) and "PAL-M" (hyphen, alternate representation) are accepted.
 bool parseVideoSystemName(std::string name, LdVideoSystem &system)
 {
     // Search VIDEO_SYSTEM_DEFAULTS for a matching name
@@ -97,6 +98,13 @@ bool parseVideoSystemName(std::string name, LdVideoSystem &system)
             return true;
         }
     }
+    
+    // Additional fallback: accept "PAL-M" as alternate representation for PAL_M
+    if (name == "PAL-M") {
+        system = LdVideoSystem::PAL_M;
+        return true;
+    }
+    
     return false;
 }
 

--- a/orc/core/metadata/lddecodemetadata.h
+++ b/orc/core/metadata/lddecodemetadata.h
@@ -48,6 +48,17 @@ enum class LdVideoSystem {
     PAL_M,      // 525-line PAL
 };
 
+/**
+ * @brief Parse video system name from fallback JSON metadata.
+ * 
+ * Accepts both "PAL_M" (underscore, canonical ld-decode form) and "PAL-M" (hyphen, alternate form).
+ * This function is used for deserialization of JSON metadata which may contain alternate representations.
+ * For SQLite reads, use video_system_from_string() instead, which only accepts the canonical "PAL_M".
+ * 
+ * @param name System name string ("PAL", "NTSC", "PAL_M", or "PAL-M")
+ * @param system Output parameter set to the parsed VideoSystem
+ * @return true if name is recognized, false otherwise
+ */
 bool parseVideoSystemName(std::string name, LdVideoSystem &system);
 
 class LdDecodeMetaData

--- a/orc/core/metadata/tbc_metadata.cpp
+++ b/orc/core/metadata/tbc_metadata.cpp
@@ -36,10 +36,17 @@ std::string video_system_to_string(VideoSystem system) {
     }
 }
 
+// Parse video system name from string.
+// For SQLite reads: the database should contain "PAL_M" (underscore) for PAL-M systems.
+// For project files: both "PAL_M" and "PAL-M" are accepted for flexibility.
+// For fallback JSON: both "PAL_M" and "PAL-M" are accepted via parseVideoSystemName().
+// Parse video system name from SQLite metadata.
+// SQLite metadata should use only the canonical name "PAL_M" (underscore).
+// For fallback JSON that may use "PAL-M" or "PAL_M", use parseVideoSystemName() instead.
 VideoSystem video_system_from_string(const std::string& name) {
     if (name == "PAL") return VideoSystem::PAL;
     if (name == "NTSC") return VideoSystem::NTSC;
-    if (name == "PAL-M" || name == "PAL_M") return VideoSystem::PAL_M;
+    if (name == "PAL_M") return VideoSystem::PAL_M;  // SQLite: only underscore form
     return VideoSystem::Unknown;
 }
 

--- a/orc/core/observers/black_psnr_observer.cpp
+++ b/orc/core/observers/black_psnr_observer.cpp
@@ -31,7 +31,7 @@ void BlackPSNRObserver::process_field(
     }
     
     const auto& descriptor = descriptor_opt.value();
-    VideoFormat format = descriptor.format;
+    const bool uses_pal_vits_layout = (descriptor.system == VideoSystem::PAL);
     
     // VITS black level locations (from ld-process-vits)
     // PAL: Line 22, 12μs start, 50μs length
@@ -42,7 +42,7 @@ void BlackPSNRObserver::process_field(
     double start_us;
     double length_us;
     
-    if (format == VideoFormat::PAL) {
+    if (uses_pal_vits_layout) {
         line = 22;
         start_us = 12.0;
         length_us = 50.0;
@@ -95,8 +95,8 @@ std::vector<double> BlackPSNRObserver::get_line_slice_ire(
     }
     
     // Calculate samples per microsecond
-    VideoFormat format = descriptor.format;
-    double us_per_line = (format == VideoFormat::PAL) ? 64.0 : 63.5;
+    const bool uses_pal_line_timing = (descriptor.system == VideoSystem::PAL);
+    double us_per_line = uses_pal_line_timing ? 64.0 : 63.5;
     double samples_per_us = static_cast<double>(descriptor.width) / us_per_line;
     
     // Calculate sample positions

--- a/orc/core/observers/white_snr_observer.cpp
+++ b/orc/core/observers/white_snr_observer.cpp
@@ -32,7 +32,7 @@ void WhiteSNRObserver::process_field(
     }
     
     const auto& descriptor = descriptor_opt.value();
-    VideoFormat format = descriptor.format;
+    const bool uses_pal_vits_layout = (descriptor.system == VideoSystem::PAL);
     
     // VITS white flag locations (from ld-process-vits)
     // PAL: Line 19, 12μs start, 8μs length
@@ -56,7 +56,7 @@ void WhiteSNRObserver::process_field(
 
     const WhiteConfig* configs = nullptr;
     size_t configs_size = 0;
-    if (format == VideoFormat::PAL) {
+    if (uses_pal_vits_layout) {
         configs = pal_configs.data();
         configs_size = pal_configs.size();
     } else {
@@ -127,8 +127,8 @@ std::vector<double> WhiteSNRObserver::get_line_slice_ire(
     }
     
     // Calculate samples per microsecond
-    VideoFormat format = descriptor.format;
-    double us_per_line = (format == VideoFormat::PAL) ? 64.0 : 63.5;
+    const bool uses_pal_line_timing = (descriptor.system == VideoSystem::PAL);
+    double us_per_line = uses_pal_line_timing ? 64.0 : 63.5;
     double samples_per_us = static_cast<double>(descriptor.width) / us_per_line;
     
     // Calculate sample positions

--- a/orc/core/stages/chroma_sink/ffmpeg_output_backend.cpp
+++ b/orc/core/stages/chroma_sink/ffmpeg_output_backend.cpp
@@ -452,10 +452,11 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
     codec_ctx_->width = width_;
     codec_ctx_->height = height_;
     
-    // Set frame rate
-    if (params.system == VideoSystem::PAL || params.system == VideoSystem::PAL_M) {
+    // Set frame rate.
+    // PAL-M uses 525-line/59.94 timing (NTSC-like cadence), not PAL 25 fps.
+    if (params.system == VideoSystem::PAL) {
         time_base_ = {1, 25};
-    } else if (params.system == VideoSystem::NTSC) {
+    } else if (params.system == VideoSystem::NTSC || params.system == VideoSystem::PAL_M) {
         time_base_ = {1001, 30000};  // 29.97 fps
     } else {
         time_base_ = {1, 25};  // Default to PAL
@@ -573,9 +574,9 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
         ORC_LOG_DEBUG("FFmpegOutputBackend: Using uncompressed {} codec", codec_id);
     } else if (codec_id == "mpeg2video") {
         // D10 (Sony IMX/XDCAM) settings
-        bool is_pal = (params.system == VideoSystem::PAL || params.system == VideoSystem::PAL_M);
-        int64_t bitrate = is_pal ? 50000000 : 49999840;  // 50 Mbps PAL, ~50 Mbps NTSC
-        int bufsize = is_pal ? 2000000 : 1668328;
+        const bool is_625_line_pal = (params.system == VideoSystem::PAL);
+        int64_t bitrate = is_625_line_pal ? 50000000 : 49999840;  // 50 Mbps PAL625, ~50 Mbps NTSC/PAL-M 525
+        int bufsize = is_625_line_pal ? 2000000 : 1668328;
         
         codec_ctx_->bit_rate = bitrate;
         codec_ctx_->rc_min_rate = bitrate;
@@ -594,7 +595,7 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
         // Set interlaced flags
         codec_ctx_->flags |= AV_CODEC_FLAG_INTERLACED_DCT | AV_CODEC_FLAG_INTERLACED_ME | AV_CODEC_FLAG_LOW_DELAY;
         
-        ORC_LOG_DEBUG("FFmpegOutputBackend: Using D10 settings ({})", is_pal ? "PAL" : "NTSC");
+        ORC_LOG_DEBUG("FFmpegOutputBackend: Using D10 settings ({})", is_625_line_pal ? "PAL625" : "525-line");
     } else if (codec_id == "libx264" || codec_id == "libx265") {
         // Use user-specified preset and quality settings
         av_opt_set(codec_ctx_->priv_data, "preset", encoder_preset_.c_str(), 0);
@@ -719,11 +720,13 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
         }
     }
     
-    // Color properties (BT.601 for PAL/NTSC) - applies to all H.264/H.265 variants
+    // Color properties for SD systems.
+    // PAL-M uses PAL-style decoding in the pipeline, but encoded SD signaling should
+    // follow 525-line conventions (same family as NTSC for matrix/primaries tagging).
     if (codec_id.find("264") != std::string::npos || 
         codec_id.find("265") != std::string::npos ||
         codec_id.find("hevc") != std::string::npos) {
-        if (params.system == VideoSystem::PAL || params.system == VideoSystem::PAL_M) {
+        if (params.system == VideoSystem::PAL) {
             codec_ctx_->color_primaries = AVCOL_PRI_BT470BG;
             codec_ctx_->color_trc = AVCOL_TRC_GAMMA28;
             codec_ctx_->colorspace = AVCOL_SPC_BT470BG;
@@ -834,8 +837,8 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
     // So our source is already in "video" range, not full range
     int colorspace = SWS_CS_ITU601;
     
-    // Set colorspace based on video system
-    if (video_system_ == VideoSystem::PAL || video_system_ == VideoSystem::PAL_M) {
+    // Set colorspace based on video system (PAL-M follows 525-line NTSC-family signaling).
+    if (video_system_ == VideoSystem::PAL) {
         colorspace = SWS_CS_ITU601;
     } else {
         colorspace = SWS_CS_SMPTE170M;  // NTSC
@@ -853,7 +856,7 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
         0, 1 << 16, 1 << 16);
     
     ORC_LOG_DEBUG("FFmpegOutputBackend: Configured color conversion: limited→limited range, colorspace {}", 
-                  video_system_ == VideoSystem::PAL ? "BT.601 (PAL)" : "SMPTE170M (NTSC)");
+                  video_system_ == VideoSystem::PAL ? "BT.601 (PAL625)" : "SMPTE170M (525-line)");
     
     // Allocate packet
     packet_ = av_packet_alloc();

--- a/orc/core/stages/dropout_correct/dropout_correct_stage.cpp
+++ b/orc/core/stages/dropout_correct/dropout_correct_stage.cpp
@@ -25,6 +25,15 @@
 
 namespace orc {
 
+namespace {
+
+bool uses_pal_dropout_geometry(VideoSystem system)
+{
+    return system == VideoSystem::PAL;
+}
+
+}
+
 // Register the stage
 ORC_REGISTER_STAGE(DropoutCorrectStage)
 
@@ -315,11 +324,11 @@ DropoutCorrectStage::DropoutLocation DropoutCorrectStage::classify_dropout(
             active_video_end = static_cast<uint32_t>(video_params->active_video_end);
         }
     } else {
-        // Fallback: use rough estimates based on format
-        if (descriptor.format == VideoFormat::PAL) {
+        // Fallback: use rough estimates based on exact system.
+        if (uses_pal_dropout_geometry(descriptor.system)) {
             color_burst_end = 100;  // ~100 samples for PAL color burst
             active_video_end = descriptor.width > 20 ? static_cast<uint32_t>(descriptor.width - 20) : 0;
-        } else if (descriptor.format == VideoFormat::NTSC) {
+        } else {
             color_burst_end = 80;   // ~80 samples for NTSC color burst  
             active_video_end = descriptor.width > 20 ? static_cast<uint32_t>(descriptor.width - 20) : 0;
         }
@@ -354,11 +363,11 @@ std::vector<DropoutRegion> DropoutCorrectStage::split_dropout_regions(
             active_video_end = static_cast<uint32_t>(video_params->active_video_end);
         }
     } else {
-        // Fallback: use rough estimates based on format
-        if (descriptor.format == VideoFormat::PAL) {
+        // Fallback: use rough estimates based on exact system.
+        if (uses_pal_dropout_geometry(descriptor.system)) {
             color_burst_end = 100;
             active_video_end = descriptor.width > 20 ? static_cast<uint32_t>(descriptor.width - 20) : 0;
-        } else if (descriptor.format == VideoFormat::NTSC) {
+        } else {
             color_burst_end = 80;
             active_video_end = descriptor.width > 20 ? static_cast<uint32_t>(descriptor.width - 20) : 0;
         }

--- a/orc/core/stages/field_map/field_map_stage.cpp
+++ b/orc/core/stages/field_map/field_map_stage.cpp
@@ -125,8 +125,8 @@ public:
                 desc.field_id = id;
                 desc.width = params->field_width;
                 desc.height = params->field_height;
-                // Convert VideoSystem to VideoFormat
-                desc.format = (params->system == VideoSystem::PAL) ? VideoFormat::PAL : VideoFormat::NTSC;
+                desc.system = params->system;
+                desc.format = video_format_from_system(params->system);
                 desc.parity = FieldParity::Top;  // Arbitrary for black fields
                 return desc;
             }

--- a/orc/core/stages/pal_comp_source/pal_comp_source_stage.cpp
+++ b/orc/core/stages/pal_comp_source/pal_comp_source_stage.cpp
@@ -19,11 +19,44 @@
 
 namespace orc {
 
+namespace {
+
+class DefaultPALCompSourceLoader final : public IPALCompSourceLoader {
+public:
+    std::shared_ptr<VideoFieldRepresentation> load(
+        const std::string& input_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const override
+    {
+        return create_tbc_representation(input_path, db_path, pcm_path, efm_path);
+    }
+};
+
+} // namespace
+
 // Register this stage with the registry
 ORC_REGISTER_STAGE(PALCompSourceStage)
 
 // Force linker to include this object file
 void force_link_PALCompSourceStage() {}
+
+PALCompSourceStage::PALCompSourceStage(std::shared_ptr<IPALCompSourceLoader> loader)
+    : loader_(std::move(loader))
+{
+    if (!loader_) {
+        loader_ = std::make_shared<DefaultPALCompSourceLoader>();
+    }
+}
+
+std::shared_ptr<VideoFieldRepresentation> PALCompSourceStage::load_representation(
+    const std::string& input_path,
+    const std::string& db_path,
+    const std::string& pcm_path,
+    const std::string& efm_path) const
+{
+    return loader_->load(input_path, db_path, pcm_path, efm_path);
+}
 
 std::vector<ArtifactPtr> PALCompSourceStage::execute(
     const std::vector<ArtifactPtr>& inputs,
@@ -87,7 +120,7 @@ std::vector<ArtifactPtr> PALCompSourceStage::execute(
     }
     
     try {
-        auto tbc_representation = create_tbc_representation(input_path, db_path, pcm_path, efm_path);
+        auto tbc_representation = load_representation(input_path, db_path, pcm_path, efm_path);
         if (!tbc_representation) {
             throw UserDataError("Failed to load TBC file (validation failed - see logs above)");
         }
@@ -124,7 +157,7 @@ std::vector<ArtifactPtr> PALCompSourceStage::execute(
         if (video_params->system != VideoSystem::PAL && 
             video_params->system != VideoSystem::PAL_M) {
             throw UserDataError(
-                "TBC file is not PAL format. Use 'Add NTSC Composite Source' for NTSC files."
+                "TBC file is not PAL or PAL-M format. Use 'Add NTSC Composite Source' for NTSC files."
             );
         }
         
@@ -137,7 +170,7 @@ std::vector<ArtifactPtr> PALCompSourceStage::execute(
         throw;
     } catch (const std::exception& e) {
         throw UserDataError(
-            std::string("Failed to load PAL TBC file '") + input_path + "': " + e.what()
+            std::string("Failed to load PAL-family TBC file '") + input_path + "': " + e.what()
         );
     }
 }
@@ -153,7 +186,7 @@ std::vector<ParameterDescriptor> PALCompSourceStage::get_parameter_descriptors(V
         ParameterDescriptor desc;
         desc.name = "input_path";
         desc.display_name = "TBC File Path";
-        desc.description = "Path to the PAL .tbc file from ld-decode (database file is automatically located)";
+        desc.description = "Path to the PAL or PAL-M .tbc file from ld-decode (database file is automatically located)";
         desc.type = ParameterType::FILE_PATH;
         desc.constraints.required = false;  // Optional - source provides 0 fields until path is set
         desc.constraints.default_value = std::string("");
@@ -265,7 +298,7 @@ std::optional<StageReport> PALCompSourceStage::generate_report() const {
     
     // Try to load the file to get actual information
     try {
-        auto representation = create_tbc_representation(input_path, db_path, pcm_path, efm_path);
+        auto representation = load_representation(input_path, db_path, pcm_path, efm_path);
         if (representation) {
             auto video_params = representation->get_video_parameters();
             

--- a/orc/core/stages/pal_comp_source/pal_comp_source_stage.h
+++ b/orc/core/stages/pal_comp_source/pal_comp_source_stage.h
@@ -19,11 +19,22 @@
 
 namespace orc {
 
+class IPALCompSourceLoader {
+public:
+    virtual ~IPALCompSourceLoader() = default;
+
+    virtual std::shared_ptr<VideoFieldRepresentation> load(
+        const std::string& input_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const = 0;
+};
+
 /**
- * @brief PAL Composite Source Stage - Loads PAL TBC files from ld-decode
+ * @brief PAL Composite Source Stage - Loads PAL-family TBC files from ld-decode
  * 
- * This stage loads a PAL TBC file and its associated database from ld-decode,
- * creating a VideoFieldRepresentation for PAL video processing.
+ * This stage loads a PAL or PAL-M TBC file and its associated database from
+ * ld-decode, creating a VideoFieldRepresentation for PAL-family processing.
  * 
  * Parameters:
  * - input_path: Path to the .tbc file
@@ -33,7 +44,7 @@ namespace orc {
  */
 class PALCompSourceStage : public DAGStage, public ParameterizedStage, public PreviewableStage {
 public:
-    PALCompSourceStage() = default;
+    explicit PALCompSourceStage(std::shared_ptr<IPALCompSourceLoader> loader = nullptr);
     ~PALCompSourceStage() override = default;
 
     // DAGStage interface
@@ -44,7 +55,7 @@ public:
             NodeType::SOURCE,
             "PAL_Comp_Source",
             "PAL Composite Source",
-            "PAL composite input source - loads PAL TBC files from ld-decode",
+            "PAL-family composite input source - loads PAL or PAL-M TBC files from ld-decode",
             0, 0,  // No inputs
             1, UINT32_MAX,  // Many outputs
             VideoFormatCompatibility::PAL_ONLY
@@ -74,9 +85,16 @@ public:
     std::optional<StageReport> generate_report() const override;
 
 private:
+    std::shared_ptr<VideoFieldRepresentation> load_representation(
+        const std::string& input_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const;
+
     // Cache the loaded representation to avoid reloading
     mutable std::string cached_input_path_;
     mutable std::shared_ptr<VideoFieldRepresentation> cached_representation_;
+    std::shared_ptr<IPALCompSourceLoader> loader_;
     
     // Store parameters for inspection
     std::map<std::string, ParameterValue> parameters_;

--- a/orc/core/stages/pal_yc_source/pal_yc_source_stage.cpp
+++ b/orc/core/stages/pal_yc_source/pal_yc_source_stage.cpp
@@ -19,11 +19,46 @@
 
 namespace orc {
 
+namespace {
+
+class DefaultPALYCSourceLoader final : public IPALYCSourceLoader {
+public:
+    std::shared_ptr<VideoFieldRepresentation> load(
+        const std::string& y_path,
+        const std::string& c_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const override
+    {
+        return create_tbc_yc_representation(y_path, c_path, db_path, pcm_path, efm_path);
+    }
+};
+
+} // namespace
+
 // Register this stage with the registry
 ORC_REGISTER_STAGE(PALYCSourceStage)
 
 // Force linker to include this object file
 void force_link_PALYCSourceStage() {}
+
+PALYCSourceStage::PALYCSourceStage(std::shared_ptr<IPALYCSourceLoader> loader)
+    : loader_(std::move(loader))
+{
+    if (!loader_) {
+        loader_ = std::make_shared<DefaultPALYCSourceLoader>();
+    }
+}
+
+std::shared_ptr<VideoFieldRepresentation> PALYCSourceStage::load_representation(
+    const std::string& y_path,
+    const std::string& c_path,
+    const std::string& db_path,
+    const std::string& pcm_path,
+    const std::string& efm_path) const
+{
+    return loader_->load(y_path, c_path, db_path, pcm_path, efm_path);
+}
 
 std::vector<ArtifactPtr> PALYCSourceStage::execute(
     const std::vector<ArtifactPtr>& inputs,
@@ -97,7 +132,7 @@ std::vector<ArtifactPtr> PALYCSourceStage::execute(
     }
     
     try {
-        auto yc_representation = create_tbc_yc_representation(y_path, c_path, db_path, pcm_path, efm_path);
+        auto yc_representation = load_representation(y_path, c_path, db_path, pcm_path, efm_path);
         if (!yc_representation) {
             throw UserDataError("Failed to load YC files (validation failed - see logs above)");
         }
@@ -126,7 +161,7 @@ std::vector<ArtifactPtr> PALYCSourceStage::execute(
         if (video_params->system != VideoSystem::PAL && 
             video_params->system != VideoSystem::PAL_M) {
             throw UserDataError(
-                "YC files are not PAL format. Use 'Add NTSC YC Source' for NTSC files."
+                "YC files are not PAL or PAL-M format. Use 'Add NTSC YC Source' for NTSC files."
             );
         }
         
@@ -140,7 +175,7 @@ std::vector<ArtifactPtr> PALYCSourceStage::execute(
         throw;
     } catch (const std::exception& e) {
         throw UserDataError(
-            std::string("Failed to load PAL YC files '") + y_path + "' + '" + c_path + "': " + e.what()
+            std::string("Failed to load PAL-family YC files '") + y_path + "' + '" + c_path + "': " + e.what()
         );
     }
 }
@@ -156,7 +191,7 @@ std::vector<ParameterDescriptor> PALYCSourceStage::get_parameter_descriptors(Vid
         ParameterDescriptor desc;
         desc.name = "y_path";
         desc.display_name = "Y (Luma) File Path";
-        desc.description = "Path to the PAL .tbcy (luma) file";
+        desc.description = "Path to the PAL or PAL-M .tbcy (luma) file";
         desc.type = ParameterType::FILE_PATH;
         desc.constraints.required = false;  // Optional - source provides 0 fields until path is set
         desc.constraints.default_value = std::string("");
@@ -169,7 +204,7 @@ std::vector<ParameterDescriptor> PALYCSourceStage::get_parameter_descriptors(Vid
         ParameterDescriptor desc;
         desc.name = "c_path";
         desc.display_name = "C (Chroma) File Path";
-        desc.description = "Path to the PAL .tbcc (chroma) file";
+        desc.description = "Path to the PAL or PAL-M .tbcc (chroma) file";
         desc.type = ParameterType::FILE_PATH;
         desc.constraints.required = false;  // Optional
         desc.constraints.default_value = std::string("");
@@ -309,7 +344,7 @@ std::optional<StageReport> PALYCSourceStage::generate_report() const {
     
     // Try to load the files to get actual information
     try {
-        auto representation = create_tbc_yc_representation(y_path_, c_path_, effective_db_path, pcm_path_, efm_path_);
+        auto representation = load_representation(y_path_, c_path_, effective_db_path, pcm_path_, efm_path_);
         if (representation) {
             auto video_params = representation->get_video_parameters();
             

--- a/orc/core/stages/pal_yc_source/pal_yc_source_stage.h
+++ b/orc/core/stages/pal_yc_source/pal_yc_source_stage.h
@@ -19,11 +19,23 @@
 
 namespace orc {
 
+class IPALYCSourceLoader {
+public:
+    virtual ~IPALYCSourceLoader() = default;
+
+    virtual std::shared_ptr<VideoFieldRepresentation> load(
+        const std::string& y_path,
+        const std::string& c_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const = 0;
+};
+
 /**
- * @brief PAL YC Source Stage - Loads PAL YC (separate Y and C) files
+ * @brief PAL YC Source Stage - Loads PAL-family YC (separate Y and C) files
  * 
- * This stage loads separate Y (luma) and C (chroma) TBC files for PAL video,
- * creating a VideoFieldRepresentation for PAL YC video processing.
+ * This stage loads separate Y (luma) and C (chroma) TBC files for PAL-family
+ * video, creating a VideoFieldRepresentation for PAL or PAL-M YC processing.
  * 
  * YC sources are typically from color-under formats like VHS or Betamax,
  * where Y and C are recorded separately. This provides better quality
@@ -42,7 +54,7 @@ namespace orc {
  */
 class PALYCSourceStage : public DAGStage, public ParameterizedStage, public PreviewableStage {
 public:
-    PALYCSourceStage() = default;
+    explicit PALYCSourceStage(std::shared_ptr<IPALYCSourceLoader> loader = nullptr);
     ~PALYCSourceStage() override = default;
 
     // DAGStage interface
@@ -53,7 +65,7 @@ public:
             NodeType::SOURCE,
             "PAL_YC_Source",
             "PAL YC Source",
-            "PAL YC input source - loads separate Y and C TBC files (color-under formats like VHS)",
+            "PAL-family YC input source - loads separate Y and C TBC files (including PAL-M color-under formats like VHS)",
             0, 0,  // No inputs
             1, UINT32_MAX,  // Many outputs
             VideoFormatCompatibility::PAL_ONLY
@@ -83,10 +95,18 @@ public:
     std::optional<StageReport> generate_report() const override;
 
 private:
+    std::shared_ptr<VideoFieldRepresentation> load_representation(
+        const std::string& y_path,
+        const std::string& c_path,
+        const std::string& db_path,
+        const std::string& pcm_path,
+        const std::string& efm_path) const;
+
     // Cache the loaded representation to avoid reloading
     mutable std::string cached_y_path_;
     mutable std::string cached_c_path_;
     mutable std::shared_ptr<VideoFieldRepresentation> cached_representation_;
+    std::shared_ptr<IPALYCSourceLoader> loader_;
     
     // Current parameters
     std::string y_path_;

--- a/orc/core/stages/video_params/video_params_stage.cpp
+++ b/orc/core/stages/video_params/video_params_stage.cpp
@@ -78,12 +78,15 @@ std::optional<SourceParameters> VideoParamsStage::build_video_parameters(
     const std::optional<SourceParameters>& source_params) const
 {
     // Start with source parameters if available, otherwise create new
+    // This function preserves the exact VideoSystem (PAL, NTSC, or PAL-M)
+    // from the source while allowing selective parameter overrides
     SourceParameters params;
     if (source_params.has_value()) {
         params = *source_params;
     }
     
     // Apply overrides for each parameter (only if set, i.e., != -1)
+    // Unset parameters (-1) inherit from source, preserving metadata defaults
     if (colour_burst_start_ >= 0) {
         params.colour_burst_start = colour_burst_start_;
     }
@@ -121,7 +124,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "colourBurstStart",
             "Colour Burst Start",
-            "Override colour burst start sample position. Set to -1 to use source value.",
+            "Override colour burst start sample position. Set to -1 to use source value. "
+            "Typical range: 120-150 samples depending on system.",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -135,7 +139,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "colourBurstEnd",
             "Colour Burst End",
-            "Override colour burst end sample position. Set to -1 to use source value.",
+            "Override colour burst end sample position. Set to -1 to use source value. "
+            "Typical range: 280-320 samples depending on system.",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -149,7 +154,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "activeVideoStart",
             "Active Video Start",
-            "Override active video start sample position. Set to -1 to use source value.",
+            "Override active video start sample position. Set to -1 to use source value. "
+            "Typical: ~200 samples for 16-bit video.",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -163,7 +169,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "activeVideoEnd",
             "Active Video End",
-            "Override active video end sample position. Set to -1 to use source value.",
+            "Override active video end sample position. Set to -1 to use source value. "
+            "Typical: 200-400 samples less than field width.",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -177,7 +184,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "firstActiveFieldLine",
             "First Active Field Line",
-            "Override first active field line number. Set to -1 to use source value.",
+            "Override first active field line (0-based). Set to -1 to use source value. "
+            "PAL: 22, NTSC: 20, PAL-M: 20",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -191,7 +199,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "lastActiveFieldLine",
             "Last Active Field Line",
-            "Override last active field line number. Set to -1 to use source value.",
+            "Override last active field line (0-based). Set to -1 to use source value. "
+            "PAL: 310, NTSC: 259, PAL-M: 259",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -205,7 +214,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "white16bIRE",
             "White 16-bit IRE",
-            "Override white level in 16-bit IRE units. Set to -1 to use source value.",
+            "Override white level in 16-bit IRE. Set to -1 to use source value. "
+            "Typical: 65535 (100 IRE). Both PAL and NTSC use 100 IRE for white.",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},
@@ -219,7 +229,8 @@ std::vector<ParameterDescriptor> VideoParamsStage::get_parameter_descriptors(Vid
         ParameterDescriptor{
             "black16bIRE",
             "Black 16-bit IRE",
-            "Override black level in 16-bit IRE units. Set to -1 to use source value.",
+            "Override black level in 16-bit IRE. Set to -1 to use source value. "
+            "PAL/PAL-M: 0 (0 IRE), NTSC: 1907 (7.5 IRE).",
             ParameterType::INT32,
             ParameterConstraints{
                 ParameterValue{int32_t(-1)},

--- a/orc/core/stages/video_params/video_params_stage.h
+++ b/orc/core/stages/video_params/video_params_stage.h
@@ -113,6 +113,31 @@ private:
  * Parameters can be set individually - unset parameters are inherited from
  * the input source. This allows partial overrides without specifying all
  * parameters.
+ * 
+ * **Supported Video Systems & Typical Active Line Ranges:**
+ * 
+ * When using this stage with specific video systems, these are the typical
+ * default active field line values to expect (inherited from source metadata):
+ * 
+ * - **PAL (625-line)**: first_active_field_line = 22, last_active_field_line = 310
+ *   - Frame geometry: 625 lines total
+ *   - Subcarrier: 4433618.75 Hz
+ *   - Use these values for standard PAL recordings
+ * 
+ * - **NTSC (525-line)**: first_active_field_line = 20, last_active_field_line = 259
+ *   - Frame geometry: 525 lines total
+ *   - Subcarrier: 3579545.45 Hz
+ *   - Use these values for standard NTSC recordings
+ * 
+ * - **PAL-M (525-line with PAL color)**: first_active_field_line = 20, last_active_field_line = 259
+ *   - Frame geometry: 525 lines total (NTSC-like) with PAL color encoding
+ *   - Subcarrier: 3575611.89 Hz
+ *   - Same active line boundaries as NTSC but with PAL colour system
+ *   - Use these field line values for Brazilian PAL-M recordings
+ * 
+ * When overriding parameters for a video system, inherit the parameters
+ * from the source (set to -1) to use these defaults, or override them
+ * if your source differs from the standard.
  */
 class VideoParamsStage : public DAGStage, public ParameterizedStage, public PreviewableStage {
 public:

--- a/orc/core/tbc_video_field_representation.cpp
+++ b/orc/core/tbc_video_field_representation.cpp
@@ -97,18 +97,9 @@ std::optional<FieldDescriptor> TBCVideoFieldRepresentation::get_descriptor(Field
     // Determine parity from field ID (alternating)
     desc.parity = (id.value() % 2 == 0) ? FieldParity::Top : FieldParity::Bottom;
     
-    // Get format from video parameters
-    switch (video_params_.system) {
-        case VideoSystem::PAL:
-        case VideoSystem::PAL_M:
-            desc.format = VideoFormat::PAL;
-            break;
-        case VideoSystem::NTSC:
-            desc.format = VideoFormat::NTSC;
-            break;
-        default:
-            desc.format = VideoFormat::Unknown;
-    }
+    // Preserve the exact system while keeping the legacy coarse format bucket.
+    desc.system = video_params_.system;
+    desc.format = video_format_from_system(video_params_.system);
     
     desc.width = video_params_.field_width;
     

--- a/orc/core/tbc_yc_video_field_representation.cpp
+++ b/orc/core/tbc_yc_video_field_representation.cpp
@@ -100,20 +100,12 @@ std::optional<FieldDescriptor> TBCYCVideoFieldRepresentation::get_descriptor(Fie
     // Determine parity from field ID (alternating)
     desc.parity = (id.value() % 2 == 0) ? FieldParity::Top : FieldParity::Bottom;
     
-    // Get format from video parameters
+    // Preserve the exact system while keeping the legacy coarse format bucket.
+    desc.system = VideoSystem::Unknown;
     desc.format = VideoFormat::Unknown;
     if (video_params_.is_valid()) {
-        switch (video_params_.system) {
-            case VideoSystem::PAL:
-            case VideoSystem::PAL_M:
-                desc.format = VideoFormat::PAL;
-                break;
-            case VideoSystem::NTSC:
-                desc.format = VideoFormat::NTSC;
-                break;
-            default:
-                desc.format = VideoFormat::Unknown;
-        }
+        desc.system = video_params_.system;
+        desc.format = video_format_from_system(video_params_.system);
         
         desc.width = video_params_.field_width;
         

--- a/orc/gui/ffmpegpresetdialog.cpp
+++ b/orc/gui/ffmpegpresetdialog.cpp
@@ -216,12 +216,29 @@ void FFmpegPresetDialog::apply_configuration()
     
     const auto& preset = current_category_presets_[preset_combo_->currentIndex()];
     
-    // Set basic output format (container-codec)
-    std::string format_string = preset.container + "-" + preset.codec;
+    // Set basic output format (container-codec), normalized to backend-supported values.
+    // Some UI presets are profile/lossless variants that map to base codecs plus extra params.
+    std::string normalized_codec = preset.codec;
+    if (normalized_codec == "h264_lossless") {
+        normalized_codec = "h264";
+    } else if (normalized_codec == "hevc_lossless") {
+        normalized_codec = "hevc";
+    } else if (normalized_codec == "av1_lossless") {
+        normalized_codec = "av1";
+    } else if (normalized_codec == "prores_4444" ||
+               normalized_codec == "prores_4444xq" ||
+               normalized_codec == "prores_videotoolbox") {
+        normalized_codec = "prores";
+    }
+
+    std::string format_string = preset.container + "-" + normalized_codec;
     set_parameter("output_format", format_string);
     
     // Set hardware encoder preference
     std::string hardware_encoder = "none";
+    if (preset.codec == "prores_videotoolbox") {
+        hardware_encoder = "videotoolbox";
+    }
     if (preset.supports_hardware && hardware_group_->isVisible() && hardware_encoder_combo_->currentIndex() > 0) {
         if (!available_hw_encoders_.empty()) {
             hardware_encoder = available_hw_encoders_[hardware_encoder_combo_->currentIndex() - 1];  // -1 for "None" option
@@ -230,12 +247,13 @@ void FFmpegPresetDialog::apply_configuration()
     set_parameter("hardware_encoder", hardware_encoder);
     
     // Set ProRes profile if applicable
-    if (preset.codec == "prores") {
-        // Extract profile from format_string (e.g., "mov-prores_hq" -> "hq")
-        std::string profile = "hq";  // Default
-        size_t underscore_pos = preset.format_string.find('_');
-        if (underscore_pos != std::string::npos) {
-            profile = preset.format_string.substr(underscore_pos + 1);
+    if (normalized_codec == "prores") {
+        // ProRes profile comes from preset variant.
+        std::string profile = "hq";
+        if (preset.codec == "prores_4444") {
+            profile = "4444";
+        } else if (preset.codec == "prores_4444xq") {
+            profile = "4444xq";
         }
         set_parameter("prores_profile", profile);
     }

--- a/orc/gui/masklineconfigdialog.cpp
+++ b/orc/gui/masklineconfigdialog.cpp
@@ -24,7 +24,7 @@ MaskLineConfigDialog::MaskLineConfigDialog(QWidget *parent)
 
     add_info_label(preset_layout, 
         "<b>Important:</b> All line numbers are <b>0-based field line indices</b>, not frame line numbers. "
-        "Each field contains ~262 lines (NTSC) or ~312 lines (PAL). Traditional 'line 21' = index 20.");
+        "NTSC/PAL-M: ~262 lines (0-261), PAL: ~312 lines (0-311). Traditional 'line 21' = index 20.");
 
     QStringList presets;
     presets << "None (Custom)" 
@@ -57,11 +57,11 @@ MaskLineConfigDialog::MaskLineConfigDialog(QWidget *parent)
     field_selection_combo_->setEnabled(false);
 
     start_line_spinbox_ = add_spinbox(custom_layout, "Start Field Line:", 0, 1000, 0,
-        "First field line number to mask (0-based, range 0-261 for NTSC, 0-311 for PAL)");
+        "First field line number to mask (0-based, NTSC/PAL-M: 0-261, PAL: 0-311)");
     start_line_spinbox_->setEnabled(false);
 
     end_line_spinbox_ = add_spinbox(custom_layout, "End Field Line:", 0, 1000, 0,
-        "Last field line number to mask (0-based, range 0-261 for NTSC, 0-311 for PAL)");
+        "Last field line number to mask (0-based, NTSC/PAL-M: 0-261, PAL: 0-311)");
     end_line_spinbox_->setEnabled(false);
 
     // Create mask level group


### PR DESCRIPTION
## Summary

Implementation of PAL-M support - this was already in the chroma-decoder code, so this was a clean up of that and an expansion of the existing PAL stages.  Performed light testing of video parameters stage, dropout correction etc.  However there needs to be more samples available for full testing.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

Passed all tests (including new specific tests for the PAL-M handling)

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [ ] Related docs were updated if needed
- [x] Linked issue (if applicable)

## Related issue

Closes #145 