### PR TITLE
macOS build fixes: icon directory creation and Nix SDK override

### DIFF
--- a/cmake/GenerateIcons.cmake
+++ b/cmake/GenerateIcons.cmake
@@ -75,6 +75,7 @@ function(generate_platform_icons SOURCE_PNG OUTPUT_DIR)
                 set(HIGHRES_PNG "${OUTPUT_DIR}/orc-gui-icon-1024.png")
                 add_custom_command(
                     OUTPUT ${HIGHRES_PNG}
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${OUTPUT_DIR}
                     COMMAND ${RSVG_CONVERT} -w 1024 -h 1024 ${SVG_SOURCE} -o ${HIGHRES_PNG}
                     DEPENDS ${SVG_SOURCE}
                     COMMENT "Generating 1024x1024 PNG from SVG for icon generation"

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,13 @@
 
         version = builtins.replaceStrings ["\n" "/" " "] ["" "-" "-"] rawVersion;
 
+        # On macOS, Nix's default stdenv uses Apple SDK 10.12.2 which pre-dates
+        # aligned_alloc (added in macOS 10.15). Override to SDK 11.0 so libc++
+        # can find ::aligned_alloc in the global namespace.
+        stdenv = if pkgs.stdenv.isDarwin
+                 then pkgs.overrideSDK pkgs.stdenv "11.0"
+                 else pkgs.stdenv;
+
         # Filtered ezpwd headers-only derivation (avoids VERSION file collisions)
         ezpwd-headers = pkgs.runCommand "ezpwd-headers" {} ''
           mkdir -p $out
@@ -66,7 +73,7 @@
         '';
 
         # Build QtNodes as a separate package (no external package needed)
-        qtNodes = pkgs.stdenv.mkDerivation {
+        qtNodes = stdenv.mkDerivation {
           pname = "qtnodes";
           version = "3.0.0";
 
@@ -107,7 +114,7 @@
         ]);
 
         # Build the decode-orc package (primary output)
-        decode-orc = pkgs.stdenv.mkDerivation {
+        decode-orc = stdenv.mkDerivation {
           pname = "decode-orc";
           version = version;
 
@@ -287,7 +294,7 @@
         };
 
         # Development shell with all dependencies for `nix develop`
-        devShells.default = pkgs.mkShell {
+        devShells.default = pkgs.mkShell.override { inherit stdenv; } {
           inputsFrom = [ decode-orc ];
 
           packages = with pkgs; [
@@ -325,6 +332,10 @@
             
             # Expose ezpwd headers for manual cmake runs inside nix develop
             export EZPWD_INCLUDE_DIR=${ezpwd-headers}
+
+            # Build CMAKE_PREFIX_PATH from all build inputs so that IDEs (e.g. CLion)
+            # launched from this shell can run cmake without extra configuration.
+            export CMAKE_PREFIX_PATH="$(echo $buildInputs $nativeBuildInputs | tr ' ' '\n' | tr '\n' ':')"
 
             # Ensure build directory exists
             mkdir -p build


### PR DESCRIPTION
## Summary

- **`cmake/GenerateIcons.cmake`**: Add `make_directory` before the `rsvg-convert` command so the output directory is guaranteed to exist on macOS, preventing a build failure when the directory hasn't been created yet.
- **`flake.nix`**: Override `stdenv` to Apple SDK 11.0 on macOS so libc++ can find `aligned_alloc` (added in macOS 10.15, absent in the default 10.12.2 SDK). Apply the same `stdenv` to the `qtNodes` derivation, the `decode-orc` derivation, and the dev shell.
- **`flake.nix`**: Export `CMAKE_PREFIX_PATH` in the `shellHook` so IDEs launched from `nix develop` (e.g. CLion) can find all build dependencies automatically without extra manual configuration.

## Test plan

- [ ] `nix develop` enters the dev shell without errors on macOS
- [ ] `cmake --build build -j` succeeds on macOS (no missing directory error from icon generation)
- [ ] `ctest --test-dir build --output-on-failure` passes