### PR TITLE
Set a frame rate on FFMPEG-driven output streams.

### DIFF
--- a/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
+++ b/orc/plugins/stages/sinks/common/ffmpeg_output_backend.cpp
@@ -774,7 +774,10 @@ bool FFmpegOutputBackend::setupEncoder(const std::string& codec_id, const orc::S
     }
     stream_->id = format_ctx_->nb_streams - 1;
     stream_->time_base = time_base_;
-    
+    // Rate not required for Matroska, but gives nice hints to players
+    stream_->avg_frame_rate = av_inv_q(time_base_);
+    stream_->r_frame_rate   = stream_->avg_frame_rate;
+
     // Copy codec parameters to stream
     ret = avcodec_parameters_from_context(stream_->codecpar, codec_ctx_);
     if (ret < 0) {


### PR DESCRIPTION
## Summary

Adjusts the FFMPEG sink to supply average and real base frame rates to the FFMPEG production of a video stream. This ensures the original constant frame rate is accounted for in the pipeline, and in a VFR format like Matroska, we at least have a hint (`TrackDefaultDuration`) for players, analyzers, and filters.

In other projects like tbc-video-exporter, the average is copied from ld-chroma-decoder's YUV4MPEG header and the real base is derived from inverting the timebase, so this brings decode-orc closer to feature parity.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

Tested on arm64 and x86_64 macOS using nix-facilitated cmake builds using real world TBC files and verified Matroska metadata with the `mediainfo` CLI and MKVToolNix's `mkvinfo`.

## Checklist

- [X] Scope is focused and minimal
- [X] Build passes locally
- [ ] Related docs were updated if needed
- [ ] Linked issue (if applicable)
